### PR TITLE
Implemented Keywords sorting base on their dependencies

### DIFF
--- a/SPID/cmake/headerlist.cmake
+++ b/SPID/cmake/headerlist.cmake
@@ -3,6 +3,7 @@ set(headers ${headers}
 	include/Defs.h
 	include/Distribute.h
 	include/LookupConfigs.h
+	include/KeywordDependencies.h
 	include/LookupForms.h
 	include/PCH.h
 )

--- a/SPID/cmake/sourcelist.cmake
+++ b/SPID/cmake/sourcelist.cmake
@@ -3,6 +3,7 @@ set(sources ${sources}
 	src/Distribute.cpp
 	src/LookupConfigs.cpp
 	src/LookupForms.cpp
+	src/KeywordDependencies.cpp
 	src/main.cpp
 	src/PCH.cpp
 )

--- a/SPID/include/Defs.h
+++ b/SPID/include/Defs.h
@@ -68,6 +68,25 @@ namespace DATA
 	};
 }
 
+/// Trait that is used to infer default sorter for Forms.
+template <class TForm>
+struct form_sorter
+{
+	using Sorter = std::less<TForm*>;
+};
+
+/// Custom ordering for keywords that ensures that dependent keywords are disitrbuted after the keywords that they depend on.
+struct KeywordDependencySorter
+{
+	bool operator()(RE::BGSKeyword* a, RE::BGSKeyword* b) const;
+};
+
+template <>
+struct form_sorter<RE::BGSKeyword>
+{
+	using Sorter = KeywordDependencySorter;
+};
+
 using FormIDPair = std::pair<
 	std::optional<RE::FormID>,
 	std::optional<std::string>>;
@@ -108,4 +127,4 @@ using FormData = std::tuple<
 template <class T>
 using FormCount = std::pair<T*, ItemCount>;
 template <class T>
-using FormDataMap = std::unordered_map<T*, std::pair<NPCCount, std::vector<FormData>>>;
+using FormDataMap = std::map<T*, std::pair<NPCCount, std::vector<FormData>>, typename form_sorter<T>::Sorter>;

--- a/SPID/include/KeywordDependencies.h
+++ b/SPID/include/KeywordDependencies.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace Dependencies
+{
+	/// Reads Forms::keywords and sorts them based on their relationship or alphabetical order.
+	/// This must be called after initial Lookup was performed.
+	void ResolveKeywords();
+}

--- a/SPID/src/KeywordDependencies.cpp
+++ b/SPID/src/KeywordDependencies.cpp
@@ -1,0 +1,199 @@
+#include "Defs.h"
+#include "LookupForms.h"
+#include "KeywordDependencies.h"
+
+/// An object that describes a keyword dependencies.
+struct DependencyNode
+{
+private:
+	RE::BGSKeyword* value;
+
+	std::unordered_map<RE::BGSKeyword*, DependencyNode*> children = {};
+
+public:
+	DependencyNode(RE::BGSKeyword* val)
+	{
+		value = val;
+		children = {};
+	}
+
+	/// Adds given node as a child of the current node.
+	/// If the same keyword has already been added, subsequent attempts will be ignored.
+	void AddChild(DependencyNode* childNode)
+	{
+		auto child = childNode->value;
+		if (child && child != value) {
+			children.try_emplace(child, childNode);
+		}
+	}
+
+	/// Checks whether current node has any dependencies.
+	bool HasDependencies()
+	{
+		return !children.empty();
+	}
+
+	/// Returns number of dependencies that this node has.
+	size_t DependenciesCount()
+	{
+		return children.size();
+	}
+
+	/// Checks if given keyword is either a direct child of the current node or is a child of one of the descendants.
+	bool IsNestedChild(RE::BGSKeyword* keyword)
+	{
+		if (!value || keyword == value || children.empty()) {
+			return false;
+		}
+
+		if (children.contains(keyword)) {
+			return true;
+		}
+
+		for (const auto [kwd, dep] : children) {
+			if (dep->IsNestedChild(keyword)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+};
+
+/// A map that associates keywords with their dependency nodes, holding all keyword's dependnecies.
+inline std::unordered_map<RE::BGSKeyword*, DependencyNode*> keywordDependencies;
+
+/// Finds an existing dependency node for given keyword.
+/// If none found, a new node will be created and placed into the map.
+DependencyNode* NodeForKeyword(RE::BGSKeyword* keyword) 
+{
+	if (keywordDependencies.contains(keyword)) {
+		return keywordDependencies.at(keyword);
+	}
+
+	auto node = new DependencyNode(keyword);
+	keywordDependencies.try_emplace(keyword, node);
+	return node;
+}
+
+/// Returns number of dependencies that given `keyword` has.
+size_t DependenciesCount(RE::BGSKeyword* keyword)
+{
+	auto iter = keywordDependencies.find(keyword);
+	return iter != keywordDependencies.end() ? iter->second->DependenciesCount() : 0;
+}
+
+/// Checks whether `parent` keyword is dependent on `dependency` keyword.
+bool IsDepending(RE::BGSKeyword* parent, RE::BGSKeyword* dependency)
+{
+	auto iter = keywordDependencies.find(parent); 
+	return iter != keywordDependencies.end() && iter->second->IsNestedChild(dependency);
+}
+
+/// Makes `parent` keyword dependent on `dependency` keyword.
+/// If `dependency` keyword is already depending on `parent` then no association will be created for `parent` -> `dependency` to avoid circular dependencies.
+void AddDependency(RE::BGSKeyword* parent, RE::BGSKeyword* dependency) 
+{
+	if (parent == dependency) {
+		logger::warn("		{} SKIP - Keyword referencing itself in its filters.", parent->GetFormEditorID());
+		return;
+	}
+
+	// If dependency is already present in parent's tree then no need to add it.
+	if (IsDepending(parent, dependency)) {
+		return;
+	}
+	
+	// Skip circular dependencies.
+	if (IsDepending(dependency, parent)) {
+		logger::warn("		{} SKIP - Keywords {} and {} use each other in their filters.", parent->GetFormEditorID() , parent->GetFormEditorID(), dependency->GetFormEditorID(), parent->GetFormEditorID(), dependency->GetFormEditorID());
+		return;
+	}
+
+	const auto parentNode = NodeForKeyword(parent);
+	const auto dependencyNode = NodeForKeyword(dependency);
+
+	parentNode->AddChild(dependencyNode);
+}
+
+void Dependencies::ResolveKeywords()
+{
+	const auto dataHandler = RE::TESDataHandler::GetSingleton(); 
+	if (!dataHandler) { return; }
+
+	logger::info("{:*^30}", "RESOLVING KEYWORDS");
+
+	// Pre-build a map of all available keywords by names.
+	std::unordered_map<std::string, RE::BGSKeyword*> allKeywords;
+
+	for (const auto kwd : dataHandler->GetFormArray<RE::BGSKeyword>()) {
+		allKeywords[kwd->GetFormEditorID()] = kwd;
+	}
+
+	// Fill keywordDependencies based on Keywords found in configs.
+	for (auto& [targetKeyword, formData] : Forms::keywords.forms) {
+		const auto& keyword = targetKeyword;
+
+		for (auto& data : formData.second) {
+			auto& [strings_ALL, strings_NOT, strings_MATCH, strings_ANY] = std::get<DATA::TYPE::kStrings>(data);
+
+			const auto findKeyword = [&](const std::string& name) -> RE::BGSKeyword* {
+				return allKeywords[name];
+			};
+
+			const auto addDependencies = [&](const StringVec& a_strings, std::function<RE::BGSKeyword*(const std::string&)> matchingKeyword) {
+				for (const auto& str : a_strings) {
+					if (const auto& kwd = matchingKeyword(str); kwd) {
+						AddDependency(keyword, kwd);
+					}
+				}
+			};
+
+			addDependencies(strings_ALL, findKeyword);
+			addDependencies(strings_NOT, findKeyword);
+			addDependencies(strings_MATCH, findKeyword);
+			addDependencies(strings_ANY, [&](const std::string& name) -> RE::BGSKeyword* {
+				for (const auto& iter : allKeywords) {
+					if (string::icontains(iter.first, name)) {
+						return iter.second;
+					}
+				}
+				return nullptr;
+			});
+		}
+	}
+
+	// Re-add all keywords back after dependnecy list has been built.
+	auto keywordForms = Forms::keywords.forms;
+	Forms::keywords.forms.clear();
+	for (const auto& [keyword, data] : keywordForms) {
+		Forms::keywords.forms[keyword] = data;
+	}
+
+	logger::info("	Keywords have been sorted: ");
+	for (const auto& [keyword, _] : Forms::keywords.forms) {
+		logger::info("		{} [0x{:X}]", keyword->GetFormEditorID(), keyword->GetFormID());
+	}
+}
+
+/// Comparator that utilizes dependencies map created with Dependencies::ResolveKeywords() to sort keywords.
+/// 
+/// Order is determined by the following rules:
+/// 1) If A is a dependency of B, then A must always be placed before B
+/// 2) If B is a dependency of A, then A must always be placed after B
+/// 3) If A has less dependencies than B, then A must be placed before B and vise versa. ("leaf" keywords should be on top)
+/// 4) If A and B has the same number of dependencies they should be ordered alphabetically.
+bool KeywordDependencySorter::operator()(RE::BGSKeyword* a, RE::BGSKeyword* b) const
+{
+	if (IsDepending(b, a)) {
+		return true;
+	} else if (IsDepending(a, b)) {
+		return false;
+	} else if (DependenciesCount(a) < DependenciesCount(b)) {
+		return true;
+	} else if (DependenciesCount(a) > DependenciesCount(b)) {
+		return false;
+	} else {
+		return _stricmp(a->GetFormEditorID(), b->GetFormEditorID()) < 0;
+	}
+}

--- a/SPID/src/LookupForms.cpp
+++ b/SPID/src/LookupForms.cpp
@@ -1,5 +1,6 @@
 #include "LookupConfigs.h"
 #include "LookupForms.h"
+#include "KeywordDependencies.h"
 
 bool Lookup::GetForms()
 {
@@ -8,7 +9,7 @@ bool Lookup::GetForms()
 			get_forms(dataHandler, a_formType, INI::configs[a_formType], a_map);
 		};
 
-	    lookup_forms("Spell", spells);
+		lookup_forms("Spell", spells);
 		lookup_forms("Perk", perks);
 		lookup_forms("Item", items);
 		lookup_forms("Shout", shouts);
@@ -18,6 +19,10 @@ bool Lookup::GetForms()
 		lookup_forms("Keyword", keywords);
 		lookup_forms("DeathItem", deathItems);
 		lookup_forms("Faction", factions);
+
+		if (keywords) {
+			Dependencies::ResolveKeywords();
+		}
 	}
 
 	const auto result = spells || perks || items || shouts || levSpells || packages || outfits || keywords || deathItems || factions;


### PR DESCRIPTION
This PR introduces strict ordering for all distributable forms by switching `FormDataMap` from `std::unordered_map` to `std::map`.
By default, all Forms except `Keywords` will be sorted by their pointer addresses.

`Keywords` are sorted using custom comparator which ensures that `Keywords` that are used by others will be distributed first.

Here is a full logic behind `Keywords` sorting.
For any pair of `Keywords` `A` and `B`  the following rules are defined:
1. If `A` is a dependency of `B`, then `A` must always be placed **before** `B`
1. If `B` is a dependency of `A`, then `A` must always be placed **after** `B`
1. If `A` has less dependencies than `B`, then `A` must be placed **before** `B` and vise versa. ("leaf" keywords should be on top)
1. If `A` and `B` has the same number of dependencies they should be ordered alphabetically.

`Keyword` dependency "graph" is built after `Lookup` loads all keywords from configs.