### PR TITLE
Made Unique NPCs who Use Templates be eligible for distribution

### DIFF
--- a/SPID/src/Distribute.cpp
+++ b/SPID/src/Distribute.cpp
@@ -73,7 +73,8 @@ void Distribute::ApplyToNPCs()
 	if (const auto dataHandler = RE::TESDataHandler::GetSingleton(); dataHandler) {
 		std::size_t totalNPCs = 0;
 		for (const auto& actorbase : dataHandler->GetFormArray<RE::TESNPC>()) {
-			if (actorbase && !actorbase->IsPlayer() && !actorbase->UsesTemplate()) {
+			
+			if (actorbase && !actorbase->IsPlayer() && (!actorbase->UsesTemplate() || actorbase->IsUnique())) {
 				Distribute(actorbase);
 				totalNPCs++;
 			}


### PR DESCRIPTION
There is a rare NPCs that have both "Unique" and "Use Template" flags set. This causes such NPCs to elude SPID as both entry points for distribution (`ApplyToNPCs` and `LeveledActor::thunk`) discard such NPCs.

Here is a sheet that illustrates all scenarios when distribution happens:
![table](https://cdn.discordapp.com/attachments/1011401624712904705/1011648495679197205/unknown.png)

The fix lets SPID distribute forms to this specific NPCs in `ApplyToNPCs` function.