### PR TITLE
Handled duplicate keyword entries

### DIFF
--- a/SPID/include/Defs.h
+++ b/SPID/include/Defs.h
@@ -135,6 +135,15 @@ struct FormData
 			return true;
 		}
 	}
+
+	bool operator==(const FormData& a_rhs) const
+	{
+		if (!form || !a_rhs.form) {
+			return false;
+		} else {
+			return form->GetFormID() == a_rhs.form->GetFormID();
+		}
+	}
 };
 
 template <class Form>

--- a/SPID/src/KeywordDependencies.cpp
+++ b/SPID/src/KeywordDependencies.cpp
@@ -124,6 +124,7 @@ void Dependencies::ResolveKeywords()
 
 	// Pre-build a map of all available keywords by names.
 	std::unordered_map<std::string, RE::BGSKeyword*> allKeywords{};
+	std::set<FormData<RE::BGSKeyword>> distrKeywords(Forms::keywords.forms.begin(), Forms::keywords.forms.end());
 
 	const auto& dataHandler = RE::TESDataHandler::GetSingleton();
 	for (const auto& kwd : dataHandler->GetFormArray<RE::BGSKeyword>()) {
@@ -139,7 +140,7 @@ void Dependencies::ResolveKeywords()
 	}
 
 	// Fill keywordDependencies based on Keywords found in configs.
-	for (auto& formData : Forms::keywords.forms) {
+	for (auto& formData : distrKeywords) {
 		auto& [strings_ALL, strings_NOT, strings_MATCH, strings_ANY] = formData.stringFilters;
 
 		const auto findKeyword = [&](const std::string& name) -> RE::BGSKeyword* {
@@ -167,15 +168,14 @@ void Dependencies::ResolveKeywords()
 		});
 	}
 
-	// Re-add all keywords back after dependency list has been built.
-	auto keywordForms = Forms::keywords.forms;
-	Forms::keywords.forms.clear();
-	for (const auto& keywordData : keywordForms) {
-		Forms::keywords.forms.emplace_back(keywordData);
-	}
+	std::sort(Forms::keywords.forms.begin(), Forms::keywords.forms.end());
+	
+	// Print only unique entries in the log.
+	FormDataVec<RE::BGSKeyword> resolvedKeywords(Forms::keywords.forms);
+	resolvedKeywords.erase(unique(resolvedKeywords.begin(), resolvedKeywords.end()), resolvedKeywords.end());
 
 	logger::info("\tKeywords have been sorted: ");
-	for (const auto& keywordData : Forms::keywords.forms) {
+	for (const auto& keywordData : resolvedKeywords) {
 		logger::info("\t\t{} [0x{:X}]", keywordData.form->GetFormEditorID(), keywordData.form->GetFormID());
 	}
 }

--- a/SPID/src/LookupForms.cpp
+++ b/SPID/src/LookupForms.cpp
@@ -11,7 +11,6 @@ bool Lookup::GetForms()
 			get_forms(dataHandler, recordName, INI::configs[recordName], a_map.forms);
 			if constexpr (std::is_same_v<RE::BGSKeyword, Form>) {
 				Dependencies::ResolveKeywords();
-				std::sort(a_map.forms.begin(), a_map.forms.end());
 			}
 			get_forms_with_level_filters(a_map);
 		};


### PR DESCRIPTION
Turned out after 6.1.0 keywords were still sorted, but after they were logged.

In this PR the issue is fixed:
- Keywords are now sorted before they'll be logged. 
- Additionally, log will contain only unique keywords in that section. (This change is redundant after #7, so consider removing it if #7 will be accepted)

