### PR TITLE
Maintaing order of keywords at which they appear in configs

### DIFF
--- a/SPID/include/DependencyResolver.h
+++ b/SPID/include/DependencyResolver.h
@@ -141,8 +141,8 @@ public:
 	DependencyResolver(const Comparator comparator = Comparator()) :
 		comparator(std::move(comparator)) {}
 
-	DependencyResolver(const std::vector<Value>& values, 
-		               const Comparator comparator = Comparator()) :
+	DependencyResolver(const std::vector<Value>& values,
+		const Comparator                         comparator = Comparator()) :
 		DependencyResolver(comparator)
 	{
 		for (const auto& value : values) {

--- a/SPID/include/DependencyResolver.h
+++ b/SPID/include/DependencyResolver.h
@@ -27,7 +27,7 @@ class DependencyResolver
 		/// <p>
 		///	<b>Use dependsOn() method to determine whether current node depends on another</b>.
 		///	</p>
-		Set<Node*> dependencies{};
+		std::set<Node*> dependencies{};
 
 		/// Flag that is used by DependencyResolver during resolution process
 		///	to detect whether given Node was already resolved.
@@ -138,10 +138,12 @@ class DependencyResolver
 	}
 
 public:
-	DependencyResolver() = default;
+	DependencyResolver(const Comparator comparator = Comparator()) :
+		comparator(std::move(comparator)) {}
 
-	DependencyResolver(const std::vector<Value>& values) :
-		comparator(std::move(Comparator()))
+	DependencyResolver(const std::vector<Value>& values, 
+		               const Comparator comparator = Comparator()) :
+		DependencyResolver(comparator)
 	{
 		for (const auto& value : values) {
 			nodes.try_emplace(value, new Node(value, comparator));

--- a/SPID/src/KeywordDependencies.cpp
+++ b/SPID/src/KeywordDependencies.cpp
@@ -10,7 +10,7 @@ struct keyword_less
 {
 	using RelativeOrderMap = Map<Keyword, int>;
 
-    const RelativeOrderMap relativeOrder;
+	const RelativeOrderMap relativeOrder;
 
 	bool operator()(const Keyword& a, const Keyword& b) const
 	{
@@ -24,13 +24,13 @@ struct keyword_less
 				return false;
 			}
 		}
-        return a->GetFormEditorID() < b->GetFormEditorID();
-    }
+		return a->GetFormEditorID() < b->GetFormEditorID();
+	}
 
-    [[nodiscard]] int getIndex(const Keyword& kwd) const
+	[[nodiscard]] int getIndex(const Keyword& kwd) const
 	{
 		if (relativeOrder.contains(kwd)) {
-		    return relativeOrder.at(kwd);
+			return relativeOrder.at(kwd);
 		}
 		return -1;
 	}
@@ -97,11 +97,11 @@ void Dependencies::ResolveKeywords()
 
 	keyword_less::RelativeOrderMap orderMap;
 
-    for (int index = 0; index < keywordForms.size(); ++index) {
+	for (int index = 0; index < keywordForms.size(); ++index) {
 		orderMap.emplace(keywordForms[index].form, index);
-    }
+	}
 
-	Resolver resolver { keyword_less(orderMap) };
+	Resolver resolver{ keyword_less(orderMap) };
 
 	/// A map that will be used to map back keywords to their data wrappers.
 	std::unordered_multimap<RE::BGSKeyword*, Forms::Data<RE::BGSKeyword>> dataKeywords;


### PR DESCRIPTION
Defined ordering of keywords during dependency resolution.

Keywords will be sorted according to the following rules:

1. Direct dependencies ( `b` <- `a`)
2. Number of dependencies ( `a.dependencies.size()` < `b.dependencies.size()`)
3. Order at which they appear in configs
4. Alphabetical. Should not be ever used, but is a fallback 🙂 so no stone unturned