### PR TITLE
Random Count

### DIFF
--- a/SPID/include/Defs.h
+++ b/SPID/include/Defs.h
@@ -54,7 +54,7 @@ struct Range
 		return value >= min && value <= max;
 	}
 
-	[[nodiscard]] bool IsExact() const 
+	[[nodiscard]] bool IsExact() const
 	{
 		return min == max;
 	}

--- a/SPID/include/Defs.h
+++ b/SPID/include/Defs.h
@@ -54,6 +54,16 @@ struct Range
 		return value >= min && value <= max;
 	}
 
+	[[nodiscard]] bool IsExact() const 
+	{
+		return min == max;
+	}
+
+	[[nodiscard]] T GetRandom() const
+	{
+		return IsExact() ? min : RNG().generate<T>(min, max);
+	}
+
 	// members
 	T min{ std::numeric_limits<T>::min() };
 	T max{ std::numeric_limits<T>::max() };
@@ -83,7 +93,10 @@ struct Traits
 	std::optional<bool>    teammate{};
 };
 
-using IdxOrCount = std::int32_t;
+using Index = std::int32_t;
+using Count = std::int32_t;
+using RandomCount = Range<Count>;
+using IndexOrCount = std::variant<Index, RandomCount>;
 using Chance = std::uint32_t;
 
 /// A standardized way of converting any object to string.

--- a/SPID/include/Distribute.h
+++ b/SPID/include/Distribute.h
@@ -77,9 +77,9 @@ namespace Distribute
 	// for now, only packages/death items use this
 	template <class Form>
 	void for_each_form(
-		const NPCData&                         a_npcData,
-		Forms::Distributables<Form>&           a_distributables,
-		const PCLevelMult::Input&              a_input,
+		const NPCData&                           a_npcData,
+		Forms::Distributables<Form>&             a_distributables,
+		const PCLevelMult::Input&                a_input,
 		std::function<bool(Form*, IndexOrCount)> a_callback)
 	{
 		auto& vec = a_distributables.GetForms(a_input.onlyPlayerLevelEntries);
@@ -138,9 +138,9 @@ namespace Distribute
 	// items
 	template <class Form>
 	void for_each_form(
-		const NPCData&                                          a_npcData,
-		Forms::Distributables<Form>&                            a_distributables,
-		const PCLevelMult::Input&                               a_input,
+		const NPCData&                                     a_npcData,
+		Forms::Distributables<Form>&                       a_distributables,
+		const PCLevelMult::Input&                          a_input,
 		std::function<bool(std::map<Form*, Count>&, bool)> a_callback)
 	{
 		auto& vec = a_distributables.GetForms(a_input.onlyPlayerLevelEntries);
@@ -150,7 +150,7 @@ namespace Distribute
 		}
 
 		std::map<Form*, Count> collectedForms{};
-		bool                          hasLeveledItems = false;
+		bool                   hasLeveledItems = false;
 
 		for (auto& formData : vec) {
 			if (!a_npcData.HasMutuallyExclusiveForm(formData.form) && detail::passed_filters(a_npcData, a_input, formData)) {

--- a/SPID/include/Distribute.h
+++ b/SPID/include/Distribute.h
@@ -86,15 +86,8 @@ namespace Distribute
 
 		for (auto& formData : vec) {
 			if (!a_npcData.HasMutuallyExclusiveForm(formData.form) && detail::passed_filters(a_npcData, a_input, formData)) {
-				if constexpr (std::is_same_v<RE::TESBoundObject, Form>) {
-					if (a_callback(formData.form, formData.count.GetRandom())) {
-						++formData.npcCount;
-					}
-				} else {
-					if (a_callback(formData.form, formData.packageIndex)) {
-						++formData.npcCount;
-					}
-				}
+				a_callback(formData.form, formData.idxOrCount);
+				++formData.npcCount;
 			}
 		}
 	}
@@ -157,7 +150,7 @@ namespace Distribute
 				if (formData.form->Is(RE::FormType::LeveledItem)) {
 					hasLeveledItems = true;
 				}
-				collectedForms.emplace(formData.form, formData.count.GetRandom());
+				collectedForms.emplace(formData.form, formData.GetCount().GetRandom());
 				++formData.npcCount;
 			}
 		}

--- a/SPID/include/Distribute.h
+++ b/SPID/include/Distribute.h
@@ -150,7 +150,7 @@ namespace Distribute
 				if (formData.form->Is(RE::FormType::LeveledItem)) {
 					hasLeveledItems = true;
 				}
-				collectedForms.emplace(formData.form, formData.GetCount().GetRandom());
+				collectedForms.emplace(formData.form, std::get<RandomCount>(formData.idxOrCount).GetRandom());
 				++formData.npcCount;
 			}
 		}

--- a/SPID/include/FormData.h
+++ b/SPID/include/FormData.h
@@ -307,15 +307,20 @@ namespace Forms
 	{
 		std::uint32_t index{ 0 };
 
-		Form*       form{ nullptr };
-		Index       packageIndex{ 0 };
-		RandomCount count{ 1, 1 };
-		FilterData  filters{};
+		Form*        form{ nullptr };
+		IndexOrCount idxOrCount{ RandomCount(1, 1) };
+		FilterData   filters{};
 
 		std::string   path{};
 		std::uint32_t npcCount{ 0 };
 
 		bool operator==(const Data& a_rhs) const;
+
+		/// <summary>
+		/// Unsafely gets a RandomCount from idxOrCount.
+		/// Onlly call this method when you're sure that idxOrCount is a RandomCount.
+		/// </summary>
+		const RandomCount& GetCount() const;
 	};
 
 	template <class Form>
@@ -393,6 +398,12 @@ bool Forms::Data<Form>::operator==(const Data& a_rhs) const
 }
 
 template <class Form>
+const RandomCount& Forms::Data<Form>::GetCount() const
+{
+	return std::get<RandomCount>(idxOrCount);
+}
+
+template <class Form>
 Forms::Distributables<Form>::operator bool()
 {
 	return !forms.empty();
@@ -443,7 +454,7 @@ void Forms::Distributables<Form>::LookupForms(RE::TESDataHandler* a_dataHandler,
 	forms.reserve(a_INIDataVec.size());
 	std::uint32_t index = 0;
 
-	for (auto& [formOrEditorID, strings, filterIDs, level, traits, packageIndex, itemsCount, chance, path] : a_INIDataVec) {
+	for (auto& [formOrEditorID, strings, filterIDs, level, traits, idxOrCount, chance, path] : a_INIDataVec) {
 		try {
 			if (auto form = detail::get_form<Form>(a_dataHandler, formOrEditorID, path); form) {
 				FormFilters filterForms{};
@@ -457,7 +468,7 @@ void Forms::Distributables<Form>::LookupForms(RE::TESDataHandler* a_dataHandler,
 				}
 
 				if (validEntry) {
-					forms.emplace_back(index, form, packageIndex, itemsCount, FilterData(strings, filterForms, level, traits, chance), path);
+					forms.emplace_back(index, form, idxOrCount, FilterData(strings, filterForms, level, traits, chance), path);
 					index++;
 				}
 			}

--- a/SPID/include/FormData.h
+++ b/SPID/include/FormData.h
@@ -315,12 +315,6 @@ namespace Forms
 		std::uint32_t npcCount{ 0 };
 
 		bool operator==(const Data& a_rhs) const;
-
-		/// <summary>
-		/// Unsafely gets a RandomCount from idxOrCount.
-		/// Onlly call this method when you're sure that idxOrCount is a RandomCount.
-		/// </summary>
-		const RandomCount& GetCount() const;
 	};
 
 	template <class Form>
@@ -395,12 +389,6 @@ bool Forms::Data<Form>::operator==(const Data& a_rhs) const
 		return false;
 	}
 	return form->GetFormID() == a_rhs.form->GetFormID();
-}
-
-template <class Form>
-const RandomCount& Forms::Data<Form>::GetCount() const
-{
-	return std::get<RandomCount>(idxOrCount);
 }
 
 template <class Form>

--- a/SPID/include/FormData.h
+++ b/SPID/include/FormData.h
@@ -307,9 +307,10 @@ namespace Forms
 	{
 		std::uint32_t index{ 0 };
 
-		Form*      form{ nullptr };
-		IdxOrCount idxOrCount{ 1 };
-		FilterData filters{};
+		Form*       form{ nullptr };
+		Index       packageIndex{ 0 };
+		RandomCount count{ 1, 1 };
+		FilterData  filters{};
 
 		std::string   path{};
 		std::uint32_t npcCount{ 0 };
@@ -442,7 +443,7 @@ void Forms::Distributables<Form>::LookupForms(RE::TESDataHandler* a_dataHandler,
 	forms.reserve(a_INIDataVec.size());
 	std::uint32_t index = 0;
 
-	for (auto& [formOrEditorID, strings, filterIDs, level, traits, idxOrCount, chance, path] : a_INIDataVec) {
+	for (auto& [formOrEditorID, strings, filterIDs, level, traits, packageIndex, itemsCount, chance, path] : a_INIDataVec) {
 		try {
 			if (auto form = detail::get_form<Form>(a_dataHandler, formOrEditorID, path); form) {
 				FormFilters filterForms{};
@@ -456,7 +457,7 @@ void Forms::Distributables<Form>::LookupForms(RE::TESDataHandler* a_dataHandler,
 				}
 
 				if (validEntry) {
-					forms.emplace_back(index, form, idxOrCount, FilterData(strings, filterForms, level, traits, chance), path);
+					forms.emplace_back(index, form, packageIndex, itemsCount, FilterData(strings, filterForms, level, traits, chance), path);
 					index++;
 				}
 			}

--- a/SPID/include/LookupConfigs.h
+++ b/SPID/include/LookupConfigs.h
@@ -46,7 +46,8 @@ namespace INI
 		Filters<FormOrEditorID> rawFormFilters{};
 		LevelFilters            levelFilters{};
 		Traits                  traits{};
-		IdxOrCount              idxOrCount{ 1 };
+		Index                   index{ 0 };
+		RandomCount             count{ 1, 1 };
 		Chance                  chance{ 100 };
 		std::string             path{};
 	};

--- a/SPID/include/LookupConfigs.h
+++ b/SPID/include/LookupConfigs.h
@@ -46,8 +46,7 @@ namespace INI
 		Filters<FormOrEditorID> rawFormFilters{};
 		LevelFilters            levelFilters{};
 		Traits                  traits{};
-		Index                   index{ 0 };
-		RandomCount             count{ 1, 1 };
+		IndexOrCount            idxOrCount{ RandomCount(1, 1) };
 		Chance                  chance{ 100 };
 		std::string             path{};
 	};

--- a/SPID/src/Distribute.cpp
+++ b/SPID/src/Distribute.cpp
@@ -89,8 +89,11 @@ namespace Distribute
 			npc->GetSpellList()->AddShouts(a_shouts);
 		});
 
-		for_each_form<RE::TESForm>(a_npcData, Forms::packages, a_input, [&](auto* a_packageOrList, [[maybe_unused]] IdxOrCount a_idx) {
-			auto packageIdx = a_idx;
+		for_each_form<RE::TESForm>(a_npcData, Forms::packages, a_input, [&](auto* a_packageOrList, [[maybe_unused]] IndexOrCount a_idx) {
+			if (!std::holds_alternative<Index>(a_idx)) {
+				return false;
+			}
+			auto packageIdx = std::get<Index>(a_idx);
 
 			if (a_packageOrList->Is(RE::FormType::Package)) {
 				auto package = a_packageOrList->As<RE::TESPackage>();
@@ -172,7 +175,7 @@ namespace Distribute
 		const auto npc = a_npcData.GetNPC();
 		const auto actor = a_npcData.GetActor();
 
-		for_each_form<RE::TESBoundObject>(a_npcData, Forms::items, a_input, [&](std::map<RE::TESBoundObject*, IdxOrCount>& a_objects, const bool a_hasLvlItem) {
+		for_each_form<RE::TESBoundObject>(a_npcData, Forms::items, a_input, [&](std::map<RE::TESBoundObject*, Count>& a_objects, const bool a_hasLvlItem) {
 			if (npc->AddObjectsToContainer(a_objects, npc)) {
 				if (a_hasLvlItem) {
 					detail::init_leveled_items(actor);

--- a/SPID/src/Distribute.cpp
+++ b/SPID/src/Distribute.cpp
@@ -90,9 +90,6 @@ namespace Distribute
 		});
 
 		for_each_form<RE::TESForm>(a_npcData, Forms::packages, a_input, [&](auto* a_packageOrList, [[maybe_unused]] IndexOrCount a_idx) {
-			if (!std::holds_alternative<Index>(a_idx)) {
-				return false;
-			}
 			auto packageIdx = std::get<Index>(a_idx);
 
 			if (a_packageOrList->Is(RE::FormType::Package)) {

--- a/SPID/src/DistributeManager.cpp
+++ b/SPID/src/DistributeManager.cpp
@@ -223,10 +223,6 @@ namespace Distribute::Event
 				const auto input = PCLevelMult::Input{ actor, npc, false };
 
 				for_each_form<RE::TESBoundObject>(npcData, Forms::deathItems, input, [&](auto* deathItem, IndexOrCount idxOrCount) {
-					if (!std::holds_alternative<RandomCount>(idxOrCount)) {
-						return false;
-					}
-
 					auto count = std::get<RandomCount>(idxOrCount);
 
 					detail::add_item(actor, deathItem, count.GetRandom());

--- a/SPID/src/DistributeManager.cpp
+++ b/SPID/src/DistributeManager.cpp
@@ -222,8 +222,14 @@ namespace Distribute::Event
 				const auto npcData = NPCData(actor, npc);
 				const auto input = PCLevelMult::Input{ actor, npc, false };
 
-				for_each_form<RE::TESBoundObject>(npcData, Forms::deathItems, input, [&](auto* a_deathItem, IdxOrCount a_count) {
-					detail::add_item(actor, a_deathItem, a_count);
+				for_each_form<RE::TESBoundObject>(npcData, Forms::deathItems, input, [&](auto* deathItem, IndexOrCount idxOrCount) {
+					if (!std::holds_alternative<RandomCount>(idxOrCount)) {
+						return false;
+					}
+
+					auto count = std::get<RandomCount>(idxOrCount);
+
+					detail::add_item(actor, deathItem, count.GetRandom());
 					return true;
 				});
 			}

--- a/SPID/src/LookupConfigs.cpp
+++ b/SPID/src/LookupConfigs.cpp
@@ -246,15 +246,28 @@ namespace INI
 			}
 
 			//ITEMCOUNT/INDEX
-			if (a_key == "Package") {  // reuse item count for package stack index
-				data.idxOrCount = 0;
-			}
+			
 			if (kIdxOrCount < size) {
-				if (const auto& str = sections[kIdxOrCount]; distribution::is_valid_entry(str)) {
-					data.idxOrCount = string::to_num<std::int32_t>(str);
+				if (a_key == "Package") {  // reuse item count for package stack index
+					if (const auto& str = sections[kIdxOrCount]; distribution::is_valid_entry(str)) {
+						data.index = string::to_num<Index>(str);
+					}
+				} else {
+					if (const auto& str = sections[kIdxOrCount]; distribution::is_valid_entry(str)) {
+						if (auto countPair = string::split(str, "/"); countPair.size() > 1) {
+							auto minCount = string::to_num<Count>(countPair[0]);
+							auto maxCount = string::to_num<Count>(countPair[1]);
+
+							data.count = RandomCount(minCount, maxCount);
+						} else {
+							auto count = string::to_num<Count>(str);
+
+							data.count = RandomCount(count, count);  // create the exact match range.
+						}
+					}
 				}
 			}
-
+		
 			//CHANCE
 			if (kChance < size) {
 				if (const auto& str = sections[kChance]; distribution::is_valid_entry(str)) {

--- a/SPID/src/LookupConfigs.cpp
+++ b/SPID/src/LookupConfigs.cpp
@@ -251,7 +251,7 @@ namespace INI
 			}
 
 			if (kIdxOrCount < size) {
-				if (a_key == "Package") { // If it's a package, then we only expect a single number.
+				if (a_key == "Package") {  // If it's a package, then we only expect a single number.
 					if (const auto& str = sections[kIdxOrCount]; distribution::is_valid_entry(str)) {
 						data.idxOrCount = string::to_num<Index>(str);
 					}

--- a/SPID/src/LookupConfigs.cpp
+++ b/SPID/src/LookupConfigs.cpp
@@ -246,7 +246,7 @@ namespace INI
 			}
 
 			//ITEMCOUNT/INDEX
-			
+
 			if (kIdxOrCount < size) {
 				if (a_key == "Package") {  // reuse item count for package stack index
 					if (const auto& str = sections[kIdxOrCount]; distribution::is_valid_entry(str)) {
@@ -267,7 +267,7 @@ namespace INI
 					}
 				}
 			}
-		
+
 			//CHANCE
 			if (kChance < size) {
 				if (const auto& str = sections[kChance]; distribution::is_valid_entry(str)) {

--- a/SPID/src/LookupConfigs.cpp
+++ b/SPID/src/LookupConfigs.cpp
@@ -246,23 +246,26 @@ namespace INI
 			}
 
 			//ITEMCOUNT/INDEX
+			if (a_key == "Package") {  // reuse item count for package stack index
+				data.idxOrCount = 0;
+			}
 
 			if (kIdxOrCount < size) {
-				if (a_key == "Package") {  // reuse item count for package stack index
+				if (a_key == "Package") { // If it's a package, then we only expect a single number.
 					if (const auto& str = sections[kIdxOrCount]; distribution::is_valid_entry(str)) {
-						data.index = string::to_num<Index>(str);
+						data.idxOrCount = string::to_num<Index>(str);
 					}
 				} else {
 					if (const auto& str = sections[kIdxOrCount]; distribution::is_valid_entry(str)) {
-						if (auto countPair = string::split(str, "/"); countPair.size() > 1) {
+						if (auto countPair = string::split(str, "-"); countPair.size() > 1) {
 							auto minCount = string::to_num<Count>(countPair[0]);
 							auto maxCount = string::to_num<Count>(countPair[1]);
 
-							data.count = RandomCount(minCount, maxCount);
+							data.idxOrCount = RandomCount(minCount, maxCount);
 						} else {
 							auto count = string::to_num<Count>(str);
 
-							data.count = RandomCount(count, count);  // create the exact match range.
+							data.idxOrCount = RandomCount(count, count);  // create the exact match range.
 						}
 					}
 				}


### PR DESCRIPTION
# Summary

_Random Count_ allows users to specify a range of number of items that should be distributed. For example, giving a random amount of gold or arrows.

# Syntax

> _Random Count_ uses `-` to define a range. It deliberately doesn't use familiar `/` to avoid confusion with level filters that appear 1 section earlier.

---

As before, users can specify exact number of items:
```ini
; Orcish Mace
Item = 0x13990|NONE|NONE|NONE|NONE|2
```
> Gives all NPCs exactly 2 Orcish Maces

But now they can also specify a range from which count will be picked randomly:
```ini
; Dwarven Sword
Item = 0x13999|NONE|NONE|NONE|NONE|5-10
```
> Gives all NPCs from 5 to 10 Dwarven Swords

And just as before, default count is `1`:
```ini
; Daedric Mace
Item = 0x139B8
```
> Gives all NPCs exactly 1 Daedric Mace