### PR TITLE
Linked Items

### DIFF
--- a/SPID/cmake/headerlist.cmake
+++ b/SPID/cmake/headerlist.cmake
@@ -8,6 +8,7 @@ set(headers ${headers}
 	include/ExclusiveGroups.h
 	include/FormData.h
 	include/KeywordDependencies.h
+	include/LinkedDistribution.h
 	include/LogBuffer.h
 	include/LookupConfigs.h
 	include/LookupFilters.h

--- a/SPID/cmake/sourcelist.cmake
+++ b/SPID/cmake/sourcelist.cmake
@@ -6,6 +6,7 @@ set(sources ${sources}
 	src/ExclusiveGroups.cpp
 	src/FormData.cpp
 	src/KeywordDependencies.cpp
+	src/LinkedDistribution.cpp
 	src/LogBuffer.cpp
 	src/LookupConfigs.cpp
 	src/LookupFilters.cpp

--- a/SPID/include/Distribute.h
+++ b/SPID/include/Distribute.h
@@ -73,79 +73,86 @@ namespace Distribute
 		bool can_equip_outfit(const RE::TESNPC* a_npc, RE::BGSOutfit* a_outfit);
 	}
 
+#pragma region Packages, Death Items
 	// old method (distributing one by one)
 	// for now, only packages/death items use this
 	template <class Form>
 	void for_each_form(
 		const NPCData&                           a_npcData,
-		Forms::Distributables<Form>&             a_distributables,
+		Forms::DataVec<Form>&              forms,
 		const PCLevelMult::Input&                a_input,
-		std::function<bool(Form*, IndexOrCount)> a_callback)
+		std::function<bool(Form*, IndexOrCount)> a_callback,
+		std::set<RE::TESForm*>*                  accumulatedForms = nullptr)
 	{
-		auto& vec = a_distributables.GetForms(a_input.onlyPlayerLevelEntries);
-
-		for (auto& formData : vec) {
+		for (auto& formData : forms) {
 			if (!a_npcData.HasMutuallyExclusiveForm(formData.form) && detail::passed_filters(a_npcData, a_input, formData)) {
+				if (accumulatedForms) {
+					accumulatedForms->insert(formData.form);
+				}
 				a_callback(formData.form, formData.idxOrCount);
 				++formData.npcCount;
 			}
 		}
 	}
+#pragma endregion
 
-	// outfits/sleep outfits
-	// skins
+#pragma region Outfits, Sleep Outfits, Skins
 	template <class Form>
 	void for_each_form(
-		const NPCData&               a_npcData,
-		Forms::Distributables<Form>& a_distributables,
-		const PCLevelMult::Input&    a_input,
-		std::function<bool(Form*)>   a_callback)
+		const NPCData&             a_npcData,
+		Forms::DataVec<Form>&      forms,
+		const PCLevelMult::Input&  a_input,
+		std::function<bool(Form*)> a_callback,
+		std::set<RE::TESForm*>*    accumulatedForms = nullptr)
 	{
-		auto& vec = a_distributables.GetForms(a_input.onlyPlayerLevelEntries);
-
-		for (auto& formData : vec) {  // Vector is reversed in FinishLookupForms
+		for (auto& formData : forms) {  // Vector is reversed in FinishLookupForms
 			if (!a_npcData.HasMutuallyExclusiveForm(formData.form) && detail::passed_filters(a_npcData, a_input, formData) && a_callback(formData.form)) {
+				if (accumulatedForms) {
+					accumulatedForms->insert(formData.form);
+				}
 				++formData.npcCount;
 				break;
 			}
 		}
 	}
+#pragma endregion
 
+	// TODO: Is this unused?
 	// outfits/sleep outfits
 	template <class Form>
 	void for_each_form(
 		const NPCData&               a_npcData,
 		Forms::Distributables<Form>& a_distributables,
-		std::function<bool(Form*)>   a_callback)
+		std::function<bool(Form*)>   a_callback,
+		std::set<RE::TESForm*>*      accumulatedForms = nullptr)
 	{
 		auto& vec = a_distributables.GetForms(false);
 
 		for (auto& formData : vec) {  // Vector is reversed in FinishLookupForms
 			if (!a_npcData.HasMutuallyExclusiveForm(formData.form) && detail::passed_filters(a_npcData, formData) && a_callback(formData.form)) {
+				if (accumulatedForms) {
+					accumulatedForms->insert(formData.form);
+				}
 				++formData.npcCount;
 				break;
 			}
 		}
 	}
 
-	// items
+#pragma region Items
+	// countable items
 	template <class Form>
 	void for_each_form(
 		const NPCData&                                     a_npcData,
-		Forms::Distributables<Form>&                       a_distributables,
+		Forms::DataVec<Form>&                              forms,
 		const PCLevelMult::Input&                          a_input,
-		std::function<bool(std::map<Form*, Count>&, bool)> a_callback)
+		std::function<bool(std::map<Form*, Count>&, bool)> a_callback,
+		std::set<RE::TESForm*>*                            accumulatedForms = nullptr)
 	{
-		auto& vec = a_distributables.GetForms(a_input.onlyPlayerLevelEntries);
-
-		if (vec.empty()) {
-			return;
-		}
-
 		std::map<Form*, Count> collectedForms{};
 		bool                   hasLeveledItems = false;
 
-		for (auto& formData : vec) {
+		for (auto& formData : forms) {
 			if (!a_npcData.HasMutuallyExclusiveForm(formData.form) && detail::passed_filters(a_npcData, a_input, formData)) {
 				if (formData.form->Is(RE::FormType::LeveledItem)) {
 					hasLeveledItems = true;
@@ -156,36 +163,36 @@ namespace Distribute
 		}
 
 		if (!collectedForms.empty()) {
+			if (accumulatedForms) {
+				std::ranges::copy(collectedForms | std::views::keys, std::inserter(*accumulatedForms, accumulatedForms->end()));
+			}
 			a_callback(collectedForms, hasLeveledItems);
 		}
 	}
+#pragma endregion
 
+#pragma region Spells, Perks, Shouts, Keywords
 	// spells, perks, shouts, keywords
 	// forms that can be added to
 	template <class Form>
 	void for_each_form(
 		NPCData&                                       a_npcData,
-		Forms::Distributables<Form>&                   a_distributables,
+		Forms::DataVec<Form>&                          forms,
 		const PCLevelMult::Input&                      a_input,
-		std::function<void(const std::vector<Form*>&)> a_callback)
+		std::function<void(const std::vector<Form*>&)> a_callback,
+		std::set<RE::TESForm*>*                        accumulatedForms = nullptr)
 	{
-		auto& vec = a_distributables.GetForms(a_input.onlyPlayerLevelEntries);
-
-		if (vec.empty()) {
-			return;
-		}
-
 		const auto npc = a_npcData.GetNPC();
 
 		std::vector<Form*> collectedForms{};
 		Set<RE::FormID>    collectedFormIDs{};
 		Set<RE::FormID>    collectedLeveledFormIDs{};
 
-		collectedForms.reserve(vec.size());
-		collectedFormIDs.reserve(vec.size());
-		collectedLeveledFormIDs.reserve(vec.size());
+		collectedForms.reserve(forms.size());
+		collectedFormIDs.reserve(forms.size());
+		collectedLeveledFormIDs.reserve(forms.size());
 
-		for (auto& formData : vec) {
+		for (auto& formData : forms) {
 			auto form = formData.form;
 			auto formID = form->GetFormID();
 			if (collectedFormIDs.contains(formID)) {
@@ -212,60 +219,20 @@ namespace Distribute
 		}
 
 		if (!collectedForms.empty()) {
+			if (accumulatedForms) {
+				accumulatedForms->insert(collectedForms.begin(), collectedForms.end());
+			}
 			a_callback(collectedForms);
 			if (!collectedLeveledFormIDs.empty()) {
 				PCLevelMult::Manager::GetSingleton()->InsertDistributedEntry(a_input, Form::FORMTYPE, collectedLeveledFormIDs);
 			}
 		}
 	}
-
-	template <class Form>
-	void for_each_form(
-		NPCData&                                       a_npcData,
-		Forms::Distributables<Form>&                   a_distributables,
-		std::function<void(const std::vector<Form*>&)> a_callback)
-	{
-		const auto& vec = a_distributables.GetForms(false);
-
-		if (vec.empty()) {
-			return;
-		}
-
-		const auto npc = a_npcData.GetNPC();
-
-		std::vector<Form*> collectedForms{};
-		Set<RE::FormID>    collectedFormIDs{};
-
-		collectedForms.reserve(vec.size());
-		collectedFormIDs.reserve(vec.size());
-
-		for (auto& formData : vec) {
-			auto form = formData.form;
-			auto formID = form->GetFormID();
-			if (collectedFormIDs.contains(formID)) {
-				continue;
-			}
-			if constexpr (std::is_same_v<RE::BGSKeyword, Form>) {
-				if (!a_npcData.HasMutuallyExclusiveForm(form) && detail::passed_filters(a_npcData, formData) && a_npcData.InsertKeyword(form->GetFormEditorID())) {
-					collectedForms.emplace_back(form);
-					collectedFormIDs.emplace(formID);
-					++formData.npcCount;
-				}
-			} else {
-				if (!a_npcData.HasMutuallyExclusiveForm(form) && detail::passed_filters(a_npcData, formData) && !detail::has_form(npc, form) && collectedFormIDs.emplace(formID).second) {
-					collectedForms.emplace_back(form);
-					++formData.npcCount;
-				}
-			}
-		}
-
-		if (!collectedForms.empty()) {
-			a_callback(collectedForms);
-		}
-	}
+#pragma endregion
 
 	void Distribute(NPCData& a_npcData, const PCLevelMult::Input& a_input);
 	void DistributeItemOutfits(NPCData& a_npcData, const PCLevelMult::Input& a_input);
 
 	void Distribute(NPCData& a_npcData, bool a_onlyLeveledEntries, bool a_noItemOutfits = false);
+
 }

--- a/SPID/include/Distribute.h
+++ b/SPID/include/Distribute.h
@@ -27,7 +27,7 @@ namespace Distribute
 			auto result = a_formData.filters.PassedFilters(a_npcData);
 
 			if (result != Filter::Result::kPass) {
-				if (result == Filter::Result::kFailRNG && hasLevelFilters) {
+				if (hasLevelFilters && result == Filter::Result::kFailRNG) {
 					pcLevelMultManager->InsertRejectedEntry(a_input, distributedFormID, index);
 				}
 				return false;

--- a/SPID/include/Distribute.h
+++ b/SPID/include/Distribute.h
@@ -79,7 +79,7 @@ namespace Distribute
 	template <class Form>
 	void for_each_form(
 		const NPCData&                           a_npcData,
-		Forms::DataVec<Form>&              forms,
+		Forms::DataVec<Form>&                    forms,
 		const PCLevelMult::Input&                a_input,
 		std::function<bool(Form*, IndexOrCount)> a_callback,
 		std::set<RE::TESForm*>*                  accumulatedForms = nullptr)

--- a/SPID/include/ExclusiveGroups.h
+++ b/SPID/include/ExclusiveGroups.h
@@ -15,15 +15,15 @@ namespace ExclusiveGroups
 		///
 		/// As a result this method configures Manager with discovered valid exclusive groups.
 		/// </summary>
-		/// <param name=""></param>
-		/// <param name="rawExclusiveGroups">A raw exclusive group entries that should be processed/</param>
+		/// <param name="dataHandler">A DataHandler that will perform the actual lookup.</param>
+		/// <param name="rawExclusiveGroups">A raw exclusive group entries that should be processed.</param>
 		void LookupExclusiveGroups(RE::TESDataHandler* const dataHandler, INI::ExclusiveGroupsVec& rawExclusiveGroups);
 
 		/// <summary>
 		/// Gets a set of all forms that are in the same exclusive group as the given form.
 		/// Note that a form can appear in multiple exclusive groups, all of those groups are returned.
 		/// </summary>
-		/// <param name="form"></param>
+		/// <param name="form">A form for which mutually exclusive forms will be returned.</param>
 		/// <returns>A union of all groups that contain a given form.</returns>
 		std::unordered_set<RE::TESForm*> MutuallyExclusiveFormsForForm(RE::TESForm* form) const;
 

--- a/SPID/include/FormData.h
+++ b/SPID/include/FormData.h
@@ -324,7 +324,7 @@ namespace Forms
 	/// A set of distributable forms that should be processed.
 	///
 	/// DistributionSet is used to conveniently pack all distributable forms into one structure.
-	/// Note that all entries store references so they are not owned by this structure. 
+	/// Note that all entries store references so they are not owned by this structure.
 	/// If you want to omit certain type of entries, you can use static empty() method to get a reference to an empty container.
 	/// </summary>
 	struct DistributionSet
@@ -344,7 +344,7 @@ namespace Forms
 
 		bool IsEmpty() const;
 
-		template<typename Form>
+		template <typename Form>
 		static DataVec<Form>& empty()
 		{
 			static DataVec<Form> empty{};

--- a/SPID/include/FormData.h
+++ b/SPID/include/FormData.h
@@ -324,21 +324,32 @@ namespace Forms
 	/// A set of distributable forms that should be processed.
 	///
 	/// DistributionSet is used to conveniently pack all distributable forms into one structure.
+	/// Note that all entries store references so they are not owned by this structure. 
+	/// If you want to omit certain type of entries, you can use static empty() method to get a reference to an empty container.
 	/// </summary>
 	struct DistributionSet
 	{
-		DataVec<RE::SpellItem>      spells{};
-		DataVec<RE::BGSPerk>        perks{};
-		DataVec<RE::TESBoundObject> items{};
-		DataVec<RE::TESShout>       shouts{};
-		DataVec<RE::TESLevSpell>    levSpells{};
-		DataVec<RE::TESForm>        packages{};
-		DataVec<RE::BGSOutfit>      outfits{};
-		DataVec<RE::BGSKeyword>     keywords{};
-		DataVec<RE::TESBoundObject> deathItems{};
-		DataVec<RE::TESFaction>     factions{};
-		DataVec<RE::BGSOutfit>      sleepOutfits{};
-		DataVec<RE::TESObjectARMO>  skins{};
+		DataVec<RE::SpellItem>&      spells;
+		DataVec<RE::BGSPerk>&        perks;
+		DataVec<RE::TESBoundObject>& items;
+		DataVec<RE::TESShout>&       shouts;
+		DataVec<RE::TESLevSpell>&    levSpells;
+		DataVec<RE::TESForm>&        packages;
+		DataVec<RE::BGSOutfit>&      outfits;
+		DataVec<RE::BGSKeyword>&     keywords;
+		DataVec<RE::TESBoundObject>& deathItems;
+		DataVec<RE::TESFaction>&     factions;
+		DataVec<RE::BGSOutfit>&      sleepOutfits;
+		DataVec<RE::TESObjectARMO>&  skins;
+
+		bool IsEmpty() const;
+
+		template<typename Form>
+		static DataVec<Form>& empty()
+		{
+			static DataVec<Form> empty{};
+			return empty;
+		}
 	};
 
 	/// <summary>

--- a/SPID/include/FormData.h
+++ b/SPID/include/FormData.h
@@ -320,6 +320,34 @@ namespace Forms
 	template <class Form>
 	using DataVec = std::vector<Data<Form>>;
 
+	
+	/// <summary>
+	/// A set of distributable forms that should be processed.
+	///
+	/// DistributionSet is used to conveniently pack all distributable forms into one structure.
+	/// </summary>
+	struct DistributionSet
+	{
+		DataVec<RE::SpellItem>      spells{};
+		DataVec<RE::BGSPerk>        perks{};
+		DataVec<RE::TESBoundObject> items{};
+		DataVec<RE::TESShout>       shouts{};
+		DataVec<RE::TESLevSpell>    levSpells{};
+		DataVec<RE::TESForm>        packages{};
+		DataVec<RE::BGSOutfit>      outfits{};
+		DataVec<RE::BGSKeyword>     keywords{};
+		DataVec<RE::TESBoundObject> deathItems{};
+		DataVec<RE::TESFaction>     factions{};
+		DataVec<RE::BGSOutfit>      sleepOutfits{};
+		DataVec<RE::TESObjectARMO>  skins{};
+	};
+
+	/// <summary>
+	/// A container that holds distributable entries for a single form type.
+	/// 
+	/// Note that this container tracks separately leveled (those using level in their filters) entries.
+	/// </summary>
+	/// <typeparam name="Form">Type of the forms to store.</typeparam>
 	template <class Form>
 	struct Distributables
 	{

--- a/SPID/include/FormData.h
+++ b/SPID/include/FormData.h
@@ -320,7 +320,6 @@ namespace Forms
 	template <class Form>
 	using DataVec = std::vector<Data<Form>>;
 
-	
 	/// <summary>
 	/// A set of distributable forms that should be processed.
 	///
@@ -344,7 +343,7 @@ namespace Forms
 
 	/// <summary>
 	/// A container that holds distributable entries for a single form type.
-	/// 
+	///
 	/// Note that this container tracks separately leveled (those using level in their filters) entries.
 	/// </summary>
 	/// <typeparam name="Form">Type of the forms to store.</typeparam>

--- a/SPID/include/FormData.h
+++ b/SPID/include/FormData.h
@@ -118,7 +118,7 @@ namespace Forms
 		}
 
 		template <class Form = RE::TESForm>
-		std::variant<Form*, const RE::TESFile*> get_form_or_mod(RE::TESDataHandler* dataHandler, const FormOrEditorID& formOrEditorID, const std::string& path, bool whitelistedOnly = false)
+		std::variant<Form*, const RE::TESFile*> get_form_or_mod(RE::TESDataHandler* const dataHandler, const FormOrEditorID& formOrEditorID, const std::string& path, bool whitelistedOnly = false)
 		{
 			Form*              form = nullptr;
 			const RE::TESFile* mod = nullptr;
@@ -235,7 +235,7 @@ namespace Forms
 			return form;
 		}
 
-		inline const RE::TESFile* get_file(RE::TESDataHandler* dataHandler, const FormOrEditorID& formOrEditorID, const std::string& path)
+		inline const RE::TESFile* get_file(RE::TESDataHandler* const dataHandler, const FormOrEditorID& formOrEditorID, const std::string& path)
 		{
 			auto formOrMod = get_form_or_mod(dataHandler, formOrEditorID, path);
 
@@ -247,7 +247,7 @@ namespace Forms
 		}
 
 		template <class Form = RE::TESForm>
-		Form* get_form(RE::TESDataHandler* dataHandler, const FormOrEditorID& formOrEditorID, const std::string& path, bool whitelistedOnly = false)
+		Form* get_form(RE::TESDataHandler* const dataHandler, const FormOrEditorID& formOrEditorID, const std::string& path, bool whitelistedOnly = false)
 		{
 			auto formOrMod = get_form_or_mod<Form>(dataHandler, formOrEditorID, path, whitelistedOnly);
 
@@ -258,7 +258,7 @@ namespace Forms
 			return nullptr;
 		}
 
-		inline bool formID_to_form(RE::TESDataHandler* a_dataHandler, RawFormVec& a_rawFormVec, FormVec& a_formVec, const std::string& a_path, bool a_all = false, bool whitelistedOnly = true)
+		inline bool formID_to_form(RE::TESDataHandler* const a_dataHandler, RawFormVec& a_rawFormVec, FormVec& a_formVec, const std::string& a_path, bool a_all = false, bool whitelistedOnly = true)
 		{
 			if (a_rawFormVec.empty()) {
 				return true;

--- a/SPID/include/LinkedDistribution.h
+++ b/SPID/include/LinkedDistribution.h
@@ -3,7 +3,8 @@
 
 namespace LinkedDistribution
 {
-	namespace INI {
+	namespace INI
+	{
 
 		struct RawLinkedItem
 		{
@@ -28,10 +29,10 @@ namespace LinkedDistribution
 		}
 	}
 
-	template<class Form>
+	template <class Form>
 	using DataSet = std::set<Forms::Data<Form>>;
 
-	template<class T>
+	template <class T>
 	using LinkedForms = std::unordered_map<RE::TESForm*, DataSet<T>>;
 
 	class Manager : public ISingleton<Manager>
@@ -58,10 +59,7 @@ namespace LinkedDistribution
 		/// <param name="rawLinkedDistribution">A raw linked item entries that should be processed.</param>
 		void LookupLinkedItems(RE::TESDataHandler* const dataHandler, INI::LinkedItemsVec& rawLinkedItems);
 
-
-
 	private:
-
 		LinkedForms<RE::SpellItem>      spells{ RECORD::kSpell };
 		LinkedForms<RE::BGSPerk>        perks{ RECORD::kPerk };
 		LinkedForms<RE::TESBoundObject> items{ RECORD::kItem };
@@ -74,6 +72,5 @@ namespace LinkedDistribution
 		LinkedForms<RE::TESFaction>     factions{ RECORD::kFaction };
 		LinkedForms<RE::BGSOutfit>      sleepOutfits{ RECORD::kSleepOutfit };
 		LinkedForms<RE::TESObjectARMO>  skins{ RECORD::kSkin };
-
 	};
 }

--- a/SPID/include/LinkedDistribution.h
+++ b/SPID/include/LinkedDistribution.h
@@ -34,7 +34,7 @@ namespace LinkedDistribution
 	template <class Form>
 	struct LinkedForms
 	{
-		friend Manager; // allow Manager to later modify forms directly.
+		friend Manager;  // allow Manager to later modify forms directly.
 
 		using Map = std::unordered_map<RE::TESForm*, DataVec<Form>>;
 
@@ -47,7 +47,7 @@ namespace LinkedDistribution
 
 	private:
 		RECORD::TYPE type;
-		Map          forms{};		
+		Map          forms{};
 
 		void Link(Form* form, const FormVec& linkedForms, const RandomCount& count, const Chance& chance, const std::string& path);
 	};
@@ -94,7 +94,6 @@ namespace LinkedDistribution
 		/// </summary>
 		template <typename Func, typename... Args>
 		void ForEachLinkedForms(Func&& func, const Args&&... args);
-
 	};
 
 #pragma region Implementation

--- a/SPID/include/LinkedDistribution.h
+++ b/SPID/include/LinkedDistribution.h
@@ -64,6 +64,8 @@ namespace LinkedDistribution
 		/// <param name="rawLinkedDistribution">A raw linked item entries that should be processed.</param>
 		void LookupLinkedItems(RE::TESDataHandler* const dataHandler, INI::LinkedItemsVec& rawLinkedItems = INI::linkedItems);
 
+		void LogLinkedItemsLookup();
+
 		/// <summary>
 		/// Calculates DistributionSet for each linked form and calls a callback for each of them.
 		/// </summary>
@@ -71,12 +73,6 @@ namespace LinkedDistribution
 		///							  This is typically distributed forms accumulated during first distribution pass.</param>
 		/// <param name="callback">A callback to be called with each DistributionSet. This is supposed to do the actual distribution.</param>
 		void ForEachLinkedDistributionSet(const std::set<RE::TESForm*>& linkedForms, std::function<void(DistributionSet&)> callback);
-
-		/// <summary>
-		/// Iterates over each type of LinkedForms and calls a callback with each of them.
-		/// </summary>
-		template <typename Func, typename... Args>
-		void ForEachLinkedForms(Func&& func, const Args&&... args);
 
 	private:
 		template <class Form>
@@ -92,6 +88,13 @@ namespace LinkedDistribution
 		LinkedForms<RE::BGSKeyword>     keywords{ RECORD::kKeyword };
 		LinkedForms<RE::TESFaction>     factions{ RECORD::kFaction };
 		LinkedForms<RE::TESObjectARMO>  skins{ RECORD::kSkin };
+
+		/// <summary>
+		/// Iterates over each type of LinkedForms and calls a callback with each of them.
+		/// </summary>
+		template <typename Func, typename... Args>
+		void ForEachLinkedForms(Func&& func, const Args&&... args);
+
 	};
 
 #pragma region Implementation

--- a/SPID/include/LinkedDistribution.h
+++ b/SPID/include/LinkedDistribution.h
@@ -1,0 +1,79 @@
+#pragma once
+#include "FormData.h"
+
+namespace LinkedDistribution
+{
+	namespace INI {
+
+		struct RawLinkedItem
+		{
+			FormOrEditorID rawForm{};
+
+			/// Raw filters in RawLinkedItem only use MATCH, there is no meaning for ALL or NOT, so they are ignored.
+			Filters<FormOrEditorID> rawFormFilters{};
+
+			RandomCount count{ 1, 1 };
+			Chance      chance{ 100 };
+
+			std::string path{};
+		};
+
+		using LinkedItemsVec = std::vector<RawLinkedItem>;
+
+		inline LinkedItemsVec linkedItems{};
+
+		namespace Parser
+		{
+			bool TryParse(const std::string& a_key, const std::string& a_value, const std::string& a_path);
+		}
+	}
+
+	template<class Form>
+	using DataSet = std::set<Forms::Data<Form>>;
+
+	template<class T>
+	using LinkedForms = std::unordered_map<RE::TESForm*, DataSet<T>>;
+
+	class Manager : public ISingleton<Manager>
+	{
+	private:
+		template <class Form>
+		const DataSet<Form>& LinkedFormsForForm(const RE::TESForm* form, const LinkedForms<Form>& linkedForms) const
+		{
+			if (const auto it = linkedForms.find(form); it != linkedForms.end()) {
+				return it->second;
+			} else {
+				static std::set<RE::TESForm*> empty{};
+				return empty;
+			}
+		}
+
+	public:
+		/// <summary>
+		/// Does a forms lookup similar to what Filters do.
+		///
+		/// As a result this method configures Manager with discovered valid linked items.
+		/// </summary>
+		/// <param name="dataHandler">A DataHandler that will perform the actual lookup.</param>
+		/// <param name="rawLinkedDistribution">A raw linked item entries that should be processed.</param>
+		void LookupLinkedItems(RE::TESDataHandler* const dataHandler, INI::LinkedItemsVec& rawLinkedItems);
+
+
+
+	private:
+
+		LinkedForms<RE::SpellItem>      spells{ RECORD::kSpell };
+		LinkedForms<RE::BGSPerk>        perks{ RECORD::kPerk };
+		LinkedForms<RE::TESBoundObject> items{ RECORD::kItem };
+		LinkedForms<RE::TESShout>       shouts{ RECORD::kShout };
+		LinkedForms<RE::TESLevSpell>    levSpells{ RECORD::kLevSpell };
+		LinkedForms<RE::TESForm>        packages{ RECORD::kPackage };
+		LinkedForms<RE::BGSOutfit>      outfits{ RECORD::kOutfit };
+		LinkedForms<RE::BGSKeyword>     keywords{ RECORD::kKeyword };
+		LinkedForms<RE::TESBoundObject> deathItems{ RECORD::kDeathItem };
+		LinkedForms<RE::TESFaction>     factions{ RECORD::kFaction };
+		LinkedForms<RE::BGSOutfit>      sleepOutfits{ RECORD::kSleepOutfit };
+		LinkedForms<RE::TESObjectARMO>  skins{ RECORD::kSkin };
+
+	};
+}

--- a/SPID/src/Distribute.cpp
+++ b/SPID/src/Distribute.cpp
@@ -202,13 +202,13 @@ namespace Distribute
 		Forms::DistributionSet entries{
 			Forms::spells.GetForms(a_input.onlyPlayerLevelEntries),
 			Forms::perks.GetForms(a_input.onlyPlayerLevelEntries),
-			{}, // items are processed separately 
+			{},  // items are processed separately
 			Forms::shouts.GetForms(a_input.onlyPlayerLevelEntries),
 			Forms::levSpells.GetForms(a_input.onlyPlayerLevelEntries),
 			Forms::packages.GetForms(a_input.onlyPlayerLevelEntries),
-			{}, // outfits are processed along with items.
+			{},  // outfits are processed along with items.
 			Forms::keywords.GetForms(a_input.onlyPlayerLevelEntries),
-			{}, // deathItems are only processed on... well, death.
+			{},  // deathItems are only processed on... well, death.
 			Forms::factions.GetForms(a_input.onlyPlayerLevelEntries),
 			Forms::sleepOutfits.GetForms(a_input.onlyPlayerLevelEntries),
 			Forms::skins.GetForms(a_input.onlyPlayerLevelEntries)

--- a/SPID/src/Distribute.cpp
+++ b/SPID/src/Distribute.cpp
@@ -188,7 +188,7 @@ namespace Distribute
 	void DistributeLinkedEntries(NPCData& npcData, const PCLevelMult::Input& input, const std::set<RE::TESForm*>& forms)
 	{
 		LinkedDistribution::Manager::GetSingleton()->ForEachLinkedDistributionSet(forms, [&](Forms::DistributionSet& set) {
-			detail::distribute(npcData, input, set, nullptr);
+			detail::distribute(npcData, input, set, nullptr); // TODO: Accumulate forms here?
 		});
 	}
 
@@ -198,6 +198,7 @@ namespace Distribute
 			return;
 		}
 
+		// TODO: Figure out how to distribute only death items perhaps?
 		Forms::DistributionSet entries{
 			Forms::spells.GetForms(a_input.onlyPlayerLevelEntries),
 			Forms::perks.GetForms(a_input.onlyPlayerLevelEntries),

--- a/SPID/src/Distribute.cpp
+++ b/SPID/src/Distribute.cpp
@@ -188,7 +188,7 @@ namespace Distribute
 	void DistributeLinkedEntries(NPCData& npcData, const PCLevelMult::Input& input, const std::set<RE::TESForm*>& forms)
 	{
 		LinkedDistribution::Manager::GetSingleton()->ForEachLinkedDistributionSet(forms, [&](Forms::DistributionSet& set) {
-			detail::distribute(npcData, input, set, nullptr); // TODO: Accumulate forms here?
+			detail::distribute(npcData, input, set, nullptr);  // TODO: Accumulate forms here?
 		});
 	}
 
@@ -202,7 +202,7 @@ namespace Distribute
 		Forms::DistributionSet entries{
 			Forms::spells.GetForms(a_input.onlyPlayerLevelEntries),
 			Forms::perks.GetForms(a_input.onlyPlayerLevelEntries),
-			Forms::DistributionSet::empty<RE::TESBoundObject>(),  // items are processed separately 
+			Forms::DistributionSet::empty<RE::TESBoundObject>(),  // items are processed separately
 			Forms::shouts.GetForms(a_input.onlyPlayerLevelEntries),
 			Forms::levSpells.GetForms(a_input.onlyPlayerLevelEntries),
 			Forms::packages.GetForms(a_input.onlyPlayerLevelEntries),
@@ -235,25 +235,27 @@ namespace Distribute
 
 		std::set<RE::TESForm*> distributedForms{};
 
-		for_each_form<RE::TESBoundObject>(a_npcData, Forms::items.GetForms(a_input.onlyPlayerLevelEntries), a_input, [&](std::map<RE::TESBoundObject*, Count>& a_objects, const bool a_hasLvlItem) {
-			if (npc->AddObjectsToContainer(a_objects, npc)) {
-				if (a_hasLvlItem) {
-					detail::init_leveled_items(actor);
+		for_each_form<RE::TESBoundObject>(
+			a_npcData, Forms::items.GetForms(a_input.onlyPlayerLevelEntries), a_input, [&](std::map<RE::TESBoundObject*, Count>& a_objects, const bool a_hasLvlItem) {
+				if (npc->AddObjectsToContainer(a_objects, npc)) {
+					if (a_hasLvlItem) {
+						detail::init_leveled_items(actor);
+					}
+					return true;
 				}
-				return true;
-			}
-			return false;
+				return false;
 			},
 			&distributedForms);
 
-		for_each_form<RE::BGSOutfit>(a_npcData, Forms::outfits.GetForms(a_input.onlyPlayerLevelEntries), a_input, [&](auto* a_outfit) {
-			if (detail::can_equip_outfit(npc, a_outfit)) {
-				actor->RemoveOutfitItems(npc->defaultOutfit);
-				npc->defaultOutfit = a_outfit;
-				npc->AddKeyword(processedOutfit);
-				return true;
-			}
-			return false;
+		for_each_form<RE::BGSOutfit>(
+			a_npcData, Forms::outfits.GetForms(a_input.onlyPlayerLevelEntries), a_input, [&](auto* a_outfit) {
+				if (detail::can_equip_outfit(npc, a_outfit)) {
+					actor->RemoveOutfitItems(npc->defaultOutfit);
+					npc->defaultOutfit = a_outfit;
+					npc->AddKeyword(processedOutfit);
+					return true;
+				}
+				return false;
 			},
 			&distributedForms);
 

--- a/SPID/src/Distribute.cpp
+++ b/SPID/src/Distribute.cpp
@@ -52,6 +52,145 @@ namespace Distribute
 
 			return true;
 		}
+
+		/// <summary>
+		/// Performs distribution of all configured forms to NPC described with a_npcData and a_input.
+		/// </summary>
+		/// <param name="a_npcData">General information about NPC that is being processed.</param>
+		/// <param name="a_input">Leveling information about NPC that is being processed.</param>
+		/// <param name="forms">A set of forms that should be distributed to NPC.</param>
+		/// <param name="accumulatedForms">An optional pointer to a set that will accumulate all distributed forms.</param>
+		void distribute(NPCData& a_npcData, const PCLevelMult::Input& a_input, Forms::DistributionSet& forms, std::set<RE::TESForm*>* accumulatedForms)
+		{
+			const auto npc = a_npcData.GetNPC();
+
+			for_each_form<RE::BGSKeyword>(
+				a_npcData, forms.keywords, a_input, [&](const std::vector<RE::BGSKeyword*>& a_keywords) {
+					npc->AddKeywords(a_keywords);
+				},
+				accumulatedForms);
+
+			for_each_form<RE::TESFaction>(
+				a_npcData, forms.factions, a_input, [&](const std::vector<RE::TESFaction*>& a_factions) {
+					npc->factions.reserve(static_cast<std::uint32_t>(a_factions.size()));
+					for (auto& faction : a_factions) {
+						npc->factions.emplace_back(RE::FACTION_RANK{ faction, 1 });
+					}
+				},
+				accumulatedForms);
+
+			for_each_form<RE::SpellItem>(
+				a_npcData, forms.spells, a_input, [&](const std::vector<RE::SpellItem*>& a_spells) {
+					npc->GetSpellList()->AddSpells(a_spells);
+				},
+				accumulatedForms);
+
+			for_each_form<RE::TESLevSpell>(
+				a_npcData, forms.levSpells, a_input, [&](const std::vector<RE::TESLevSpell*>& a_levSpells) {
+					npc->GetSpellList()->AddLevSpells(a_levSpells);
+				},
+				accumulatedForms);
+
+			for_each_form<RE::BGSPerk>(
+				a_npcData, forms.perks, a_input, [&](const std::vector<RE::BGSPerk*>& a_perks) {
+					npc->AddPerks(a_perks, 1);
+				},
+				accumulatedForms);
+
+			for_each_form<RE::TESShout>(
+				a_npcData, forms.shouts, a_input, [&](const std::vector<RE::TESShout*>& a_shouts) {
+					npc->GetSpellList()->AddShouts(a_shouts);
+				},
+				accumulatedForms);
+
+			for_each_form<RE::TESForm>(
+				a_npcData, forms.packages, a_input, [&](auto* a_packageOrList, [[maybe_unused]] IndexOrCount a_idx) {
+					auto packageIdx = std::get<Index>(a_idx);
+
+					if (a_packageOrList->Is(RE::FormType::Package)) {
+						auto package = a_packageOrList->As<RE::TESPackage>();
+
+						if (packageIdx > 0) {
+							--packageIdx;  //get actual position we want to insert at
+						}
+
+						auto& packageList = npc->aiPackages.packages;
+						if (std::ranges::find(packageList, package) == packageList.end()) {
+							if (packageList.empty() || packageIdx == 0) {
+								packageList.push_front(package);
+							} else {
+								auto idxIt = packageList.begin();
+								for (idxIt; idxIt != packageList.end(); ++idxIt) {
+									auto idx = std::distance(packageList.begin(), idxIt);
+									if (packageIdx == idx) {
+										break;
+									}
+								}
+								if (idxIt != packageList.end()) {
+									packageList.insert_after(idxIt, package);
+								}
+							}
+							return true;
+						}
+					} else if (a_packageOrList->Is(RE::FormType::FormList)) {
+						auto packageList = a_packageOrList->As<RE::BGSListForm>();
+
+						switch (packageIdx) {
+						case 0:
+							npc->defaultPackList = packageList;
+							break;
+						case 1:
+							npc->spectatorOverRidePackList = packageList;
+							break;
+						case 2:
+							npc->observeCorpseOverRidePackList = packageList;
+							break;
+						case 3:
+							npc->guardWarnOverRidePackList = packageList;
+							break;
+						case 4:
+							npc->enterCombatOverRidePackList = packageList;
+							break;
+						default:
+							break;
+						}
+						return true;
+					}
+
+					return false;
+				},
+				accumulatedForms);
+
+			for_each_form<RE::TESObjectARMO>(
+				a_npcData, forms.skins, a_input, [&](auto* a_skin) {
+					if (npc->skin != a_skin) {
+						npc->skin = a_skin;
+						return true;
+					}
+					return false;
+				},
+				accumulatedForms);
+
+			for_each_form<RE::BGSOutfit>(
+				a_npcData, forms.sleepOutfits, a_input, [&](auto* a_outfit) {
+					if (npc->sleepOutfit != a_outfit) {
+						npc->sleepOutfit = a_outfit;
+						return true;
+					}
+					return false;
+				},
+				accumulatedForms);
+		}
+
+	}
+
+	// This only does one-level linking. So that linked entries won't trigger another level of distribution.
+	void DistributeLinkedEntries(NPCData& npcData, const PCLevelMult::Input& a_input, const std::set<RE::TESForm*>& forms)
+	{
+		// TODO: Get linked entries and repeat distribution for them.
+
+		Forms::DistributionSet entries{};
+		detail::distribute(npcData, a_input, entries, nullptr);
 	}
 
 	void Distribute(NPCData& a_npcData, const PCLevelMult::Input& a_input)
@@ -60,107 +199,29 @@ namespace Distribute
 			return;
 		}
 
-		const auto npc = a_npcData.GetNPC();
+		Forms::DistributionSet entries{
+			Forms::spells.GetForms(a_input.onlyPlayerLevelEntries),
+			Forms::perks.GetForms(a_input.onlyPlayerLevelEntries),
+			{}, // items are processed separately 
+			Forms::shouts.GetForms(a_input.onlyPlayerLevelEntries),
+			Forms::levSpells.GetForms(a_input.onlyPlayerLevelEntries),
+			Forms::packages.GetForms(a_input.onlyPlayerLevelEntries),
+			{}, // outfits are processed along with items.
+			Forms::keywords.GetForms(a_input.onlyPlayerLevelEntries),
+			{}, // deathItems are only processed on... well, death.
+			Forms::factions.GetForms(a_input.onlyPlayerLevelEntries),
+			Forms::sleepOutfits.GetForms(a_input.onlyPlayerLevelEntries),
+			Forms::skins.GetForms(a_input.onlyPlayerLevelEntries)
+		};
 
-		for_each_form<RE::BGSKeyword>(a_npcData, Forms::keywords, a_input, [&](const std::vector<RE::BGSKeyword*>& a_keywords) {
-			npc->AddKeywords(a_keywords);
-		});
+		std::set<RE::TESForm*> distributedForms{};
 
-		for_each_form<RE::TESFaction>(a_npcData, Forms::factions, a_input, [&](const std::vector<RE::TESFaction*>& a_factions) {
-			npc->factions.reserve(static_cast<std::uint32_t>(a_factions.size()));
-			for (auto& faction : a_factions) {
-				npc->factions.emplace_back(RE::FACTION_RANK{ faction, 1 });
-			}
-		});
+		detail::distribute(a_npcData, a_input, entries, &distributedForms);
+		// TODO: We can now log per-NPC distributed forms.
 
-		for_each_form<RE::SpellItem>(a_npcData, Forms::spells, a_input, [&](const std::vector<RE::SpellItem*>& a_spells) {
-			npc->GetSpellList()->AddSpells(a_spells);
-		});
-
-		for_each_form<RE::TESLevSpell>(a_npcData, Forms::levSpells, a_input, [&](const std::vector<RE::TESLevSpell*>& a_levSpells) {
-			npc->GetSpellList()->AddLevSpells(a_levSpells);
-		});
-
-		for_each_form<RE::BGSPerk>(a_npcData, Forms::perks, a_input, [&](const std::vector<RE::BGSPerk*>& a_perks) {
-			npc->AddPerks(a_perks, 1);
-		});
-
-		for_each_form<RE::TESShout>(a_npcData, Forms::shouts, a_input, [&](const std::vector<RE::TESShout*>& a_shouts) {
-			npc->GetSpellList()->AddShouts(a_shouts);
-		});
-
-		for_each_form<RE::TESForm>(a_npcData, Forms::packages, a_input, [&](auto* a_packageOrList, [[maybe_unused]] IndexOrCount a_idx) {
-			auto packageIdx = std::get<Index>(a_idx);
-
-			if (a_packageOrList->Is(RE::FormType::Package)) {
-				auto package = a_packageOrList->As<RE::TESPackage>();
-
-				if (packageIdx > 0) {
-					--packageIdx;  //get actual position we want to insert at
-				}
-
-				auto& packageList = npc->aiPackages.packages;
-				if (std::ranges::find(packageList, package) == packageList.end()) {
-					if (packageList.empty() || packageIdx == 0) {
-						packageList.push_front(package);
-					} else {
-						auto idxIt = packageList.begin();
-						for (idxIt; idxIt != packageList.end(); ++idxIt) {
-							auto idx = std::distance(packageList.begin(), idxIt);
-							if (packageIdx == idx) {
-								break;
-							}
-						}
-						if (idxIt != packageList.end()) {
-							packageList.insert_after(idxIt, package);
-						}
-					}
-					return true;
-				}
-			} else if (a_packageOrList->Is(RE::FormType::FormList)) {
-				auto packageList = a_packageOrList->As<RE::BGSListForm>();
-
-				switch (packageIdx) {
-				case 0:
-					npc->defaultPackList = packageList;
-					break;
-				case 1:
-					npc->spectatorOverRidePackList = packageList;
-					break;
-				case 2:
-					npc->observeCorpseOverRidePackList = packageList;
-					break;
-				case 3:
-					npc->guardWarnOverRidePackList = packageList;
-					break;
-				case 4:
-					npc->enterCombatOverRidePackList = packageList;
-					break;
-				default:
-					break;
-				}
-
-				return true;
-			}
-
-			return false;
-		});
-
-		for_each_form<RE::TESObjectARMO>(a_npcData, Forms::skins, a_input, [&](auto* a_skin) {
-			if (npc->skin != a_skin) {
-				npc->skin = a_skin;
-				return true;
-			}
-			return false;
-		});
-
-		for_each_form<RE::BGSOutfit>(a_npcData, Forms::sleepOutfits, a_input, [&](auto* a_outfit) {
-			if (npc->sleepOutfit != a_outfit) {
-				npc->sleepOutfit = a_outfit;
-				return true;
-			}
-			return false;
-		});
+		if (!distributedForms.empty()) {
+			DistributeLinkedEntries(a_npcData, a_input, distributedForms);
+		}
 	}
 
 	void DistributeItemOutfits(NPCData& a_npcData, const PCLevelMult::Input& a_input)
@@ -172,7 +233,7 @@ namespace Distribute
 		const auto npc = a_npcData.GetNPC();
 		const auto actor = a_npcData.GetActor();
 
-		for_each_form<RE::TESBoundObject>(a_npcData, Forms::items, a_input, [&](std::map<RE::TESBoundObject*, Count>& a_objects, const bool a_hasLvlItem) {
+		for_each_form<RE::TESBoundObject>(a_npcData, Forms::items.GetForms(a_input.onlyPlayerLevelEntries), a_input, [&](std::map<RE::TESBoundObject*, Count>& a_objects, const bool a_hasLvlItem) {
 			if (npc->AddObjectsToContainer(a_objects, npc)) {
 				if (a_hasLvlItem) {
 					detail::init_leveled_items(actor);
@@ -182,7 +243,7 @@ namespace Distribute
 			return false;
 		});
 
-		for_each_form<RE::BGSOutfit>(a_npcData, Forms::outfits, a_input, [&](auto* a_outfit) {
+		for_each_form<RE::BGSOutfit>(a_npcData, Forms::outfits.GetForms(a_input.onlyPlayerLevelEntries), a_input, [&](auto* a_outfit) {
 			if (detail::can_equip_outfit(npc, a_outfit)) {
 				actor->RemoveOutfitItems(npc->defaultOutfit);
 				npc->defaultOutfit = a_outfit;

--- a/SPID/src/DistributeManager.cpp
+++ b/SPID/src/DistributeManager.cpp
@@ -222,7 +222,7 @@ namespace Distribute::Event
 				const auto npcData = NPCData(actor, npc);
 				const auto input = PCLevelMult::Input{ actor, npc, false };
 
-				for_each_form<RE::TESBoundObject>(npcData, Forms::deathItems, input, [&](auto* deathItem, IndexOrCount idxOrCount) {
+				for_each_form<RE::TESBoundObject>(npcData, Forms::deathItems.GetForms(input.onlyPlayerLevelEntries), input, [&](auto* deathItem, IndexOrCount idxOrCount) {
 					auto count = std::get<RandomCount>(idxOrCount);
 
 					detail::add_item(actor, deathItem, count.GetRandom());

--- a/SPID/src/ExclusiveGroups.cpp
+++ b/SPID/src/ExclusiveGroups.cpp
@@ -28,11 +28,7 @@ void ExclusiveGroups::Manager::LookupExclusiveGroups(RE::TESDataHandler* const d
 	}
 
 	// Remove empty groups
-	for (auto& [name, forms] : groups) {
-		if (forms.empty()) {
-			groups.erase(name);
-		}
-	}
+	std::erase_if(groups, [](const auto& pair) { return pair.second.empty(); });
 
 	for (auto& [name, forms] : groups) {
 		for (auto& form : forms) {

--- a/SPID/src/FormData.cpp
+++ b/SPID/src/FormData.cpp
@@ -21,3 +21,8 @@ std::size_t Forms::GetTotalLeveledEntries()
 
 	return size;
 }
+
+bool Forms::DistributionSet::IsEmpty() const
+{
+	return spells.empty() && perks.empty() && items.empty() && shouts.empty() && levSpells.empty() && packages.empty() && outfits.empty() && keywords.empty() && deathItems.empty() && factions.empty() && sleepOutfits.empty() && skins.empty();
+}

--- a/SPID/src/LinkedDistribution.cpp
+++ b/SPID/src/LinkedDistribution.cpp
@@ -1,81 +1,129 @@
 #include "LinkedDistribution.h"
 #include "FormData.h"
 
-#pragma region Parsing
-bool           LinkedDistribution::INI::Parser::TryParse(const std::string& a_key, const std::string& a_value, const std::string& a_path)
+namespace LinkedDistribution
 {
-	if (a_key != "LinkedItem") {
-		return false;
+
+	using namespace Forms;
+
+#pragma region Parsing
+	bool INI::Parser::TryParse(const std::string& a_key, const std::string& a_value, const std::string& a_path)
+	{
+		if (a_key != "LinkedItem") {
+			return false;
+		}
+
+		const auto sections = string::split(a_value, "|");
+		const auto size = sections.size();
+
+		if (size < 2) {
+			logger::warn("IGNORED: LinkedItem must have a form and at least one filter name: {} = {}"sv, a_key, a_value);
+			return false;
+		}
+
+		auto split_IDs = distribution::split_entry(sections[1]);
+
+		if (split_IDs.empty()) {
+			logger::warn("ExclusiveGroup must have at least one Form Filter : {} = {}"sv, a_key, a_value);
+			return false;
+		}
+
+		// TODO: Parse count and chance
+
+		INI::RawLinkedItem item{};
+		item.rawForm = sections[0];
+		item.path = a_path;
+
+		for (auto& IDs : split_IDs) {
+			item.rawFormFilters.MATCH.push_back(distribution::get_record(IDs));
+		}
 	}
-
-	const auto sections = string::split(a_value, "|");
-	const auto size = sections.size();
-
-	if (size < 2) {
-		logger::warn("IGNORED: LinkedItem must have a form and at least one filter name: {} = {}"sv, a_key, a_value);
-		return false;
-	}
-
-	auto split_IDs = distribution::split_entry(sections[1]);
-
-	if (split_IDs.empty()) {
-		logger::warn("ExclusiveGroup must have at least one Form Filter : {} = {}"sv, a_key, a_value);
-		return false;
-	}
-
-	LinkedDistribution::INI::RawLinkedItem item{};
-	item.rawForm = sections[0];
-	item.path = a_path;
-
-	for (auto& IDs : split_IDs) {
-		item.rawFormFilters.MATCH.push_back(distribution::get_record(IDs));
-	}
-}
 #pragma endregion
 
 #pragma region Lookup
-void           LinkedDistribution::Manager::LookupLinkedItems(RE::TESDataHandler* const dataHandler, INI::LinkedItemsVec& rawLinkedItems)
-{
-	using namespace Forms;
+	void Manager::LookupLinkedItems(RE::TESDataHandler* const dataHandler, INI::LinkedItemsVec& rawLinkedItems)
+	{
+		using namespace Forms;
 
-	// TODO: Figure out templates here.
+		// TODO: Figure out templates here.
 
-	for (auto& [rawForm, filterIDs, count, chance, path] : rawLinkedItems) {
-		try {
-			if (const auto form = Forms::detail::get_form(dataHandler, rawForm, path); form) {
-				/*auto& forms = linkedForms[form];
+		for (auto& [rawForm, filterIDs, count, chance, path] : rawLinkedItems) {
+			try {
+				if (const auto form = detail::get_form(dataHandler, rawForm, path); form) {
+					/*auto& forms = linkedForms[form];
 				FormVec match{};
 
-				if (Forms::detail::formID_to_form(dataHandler, filterIDs.MATCH, match, path, false, false)) {
+				if (detail::formID_to_form(dataHandler, filterIDs.MATCH, match, path, false, false)) {
 					for (const auto& form : match) {
 						if (std::holds_alternative<RE::TESForm*>(form)) {
 							forms.insert(std::get<RE::TESForm*>(form));
 						}
 					}
 				}*/
+				}
+			} catch (const Lookup::UnknownFormIDException& e) {
+				buffered_logger::error("\t[{}] [0x{:X}] ({}) FAIL - formID doesn't exist", e.path, e.formID, e.modName.value_or(""));
+			} catch (const Lookup::InvalidKeywordException& e) {
+				buffered_logger::error("\t[{}] [0x{:X}] ({}) FAIL - keyword does not have a valid editorID", e.path, e.formID, e.modName.value_or(""));
+			} catch (const Lookup::KeywordNotFoundException& e) {
+				if (e.isDynamic) {
+					buffered_logger::critical("\t[{}] {} FAIL - couldn't create keyword", e.path, e.editorID);
+				} else {
+					buffered_logger::critical("\t[{}] {} FAIL - couldn't get existing keyword", e.path, e.editorID);
+				}
+			} catch (const Lookup::UnknownEditorIDException& e) {
+				buffered_logger::error("\t[{}] ({}) FAIL - editorID doesn't exist", e.path, e.editorID);
+			} catch (const Lookup::MalformedEditorIDException& e) {
+				buffered_logger::error("\t[{}] FAIL - editorID can't be empty", e.path);
+			} catch (const Lookup::InvalidFormTypeException& e) {
+				// Whitelisting is disabled, so this should not occur
+			} catch (const Lookup::UnknownPluginException& e) {
+				// Likewise, we don't expect plugin names in linked forms.
 			}
-		} catch (const Lookup::UnknownFormIDException& e) {
-			buffered_logger::error("\t[{}] [0x{:X}] ({}) FAIL - formID doesn't exist", e.path, e.formID, e.modName.value_or(""));
-		} catch (const Lookup::InvalidKeywordException& e) {
-			buffered_logger::error("\t[{}] [0x{:X}] ({}) FAIL - keyword does not have a valid editorID", e.path, e.formID, e.modName.value_or(""));
-		} catch (const Lookup::KeywordNotFoundException& e) {
-			if (e.isDynamic) {
-				buffered_logger::critical("\t[{}] {} FAIL - couldn't create keyword", e.path, e.editorID);
-			} else {
-				buffered_logger::critical("\t[{}] {} FAIL - couldn't get existing keyword", e.path, e.editorID);
+		}
+
+		// Remove empty linked forms
+		//std::erase_if(linkedForms, [](const auto& pair) { return pair.second.empty(); });
+	}
+
+	void Manager::ForEachLinkedDistributionSet(const std::set<RE::TESForm*>& targetForms, std::function<void(DistributionSet&)> performDistribution)
+	{
+		for (const auto form : targetForms) {
+			auto& linkedSpells = LinkedFormsForForm(form, spells);
+			auto& linkedPerks = LinkedFormsForForm(form, perks);
+			auto& linkedItems = LinkedFormsForForm(form, items);
+			auto& linkedShouts = LinkedFormsForForm(form, shouts);
+			auto& linkedLevSpells = LinkedFormsForForm(form, levSpells);
+			auto& linkedPackages = LinkedFormsForForm(form, packages);
+			auto& linkedOutfits = LinkedFormsForForm(form, outfits);
+			auto& linkedKeywords = LinkedFormsForForm(form, keywords);
+			auto& linkedDeathItems = LinkedFormsForForm(form, deathItems);
+			auto& linkedFactions = LinkedFormsForForm(form, factions);
+			auto& linkedSleepOutfits = LinkedFormsForForm(form, sleepOutfits);
+			auto& linkedSkins = LinkedFormsForForm(form, skins);
+
+			DistributionSet linkedEntries{
+				linkedSpells,
+				linkedPerks,
+				linkedItems,
+				linkedShouts,
+				linkedLevSpells,
+				linkedPackages,
+				linkedOutfits,
+				linkedKeywords,
+				linkedDeathItems,
+				linkedFactions,
+				linkedSleepOutfits,
+				linkedSkins
+			};
+
+			if (linkedEntries.IsEmpty()) {
+				continue;
 			}
-		} catch (const Lookup::UnknownEditorIDException& e) {
-			buffered_logger::error("\t[{}] ({}) FAIL - editorID doesn't exist", e.path, e.editorID);
-		} catch (const Lookup::MalformedEditorIDException& e) {
-			buffered_logger::error("\t[{}] FAIL - editorID can't be empty", e.path);
-		} catch (const Lookup::InvalidFormTypeException& e) {
-			// Whitelisting is disabled, so this should not occur
-		} catch (const Lookup::UnknownPluginException& e) {
-			// Likewise, we don't expect plugin names in linked forms.
+
+			performDistribution(linkedEntries);
 		}
 	}
 
-	// Remove empty linked forms
-	//std::erase_if(linkedForms, [](const auto& pair) { return pair.second.empty(); });
-}
 #pragma endregion
+}

--- a/SPID/src/LinkedDistribution.cpp
+++ b/SPID/src/LinkedDistribution.cpp
@@ -2,7 +2,7 @@
 #include "FormData.h"
 
 #pragma region Parsing
-bool LinkedDistribution::INI::Parser::TryParse(const std::string& a_key, const std::string& a_value, const std::string& a_path)
+bool           LinkedDistribution::INI::Parser::TryParse(const std::string& a_key, const std::string& a_value, const std::string& a_path)
 {
 	if (a_key != "LinkedItem") {
 		return false;
@@ -34,12 +34,11 @@ bool LinkedDistribution::INI::Parser::TryParse(const std::string& a_key, const s
 #pragma endregion
 
 #pragma region Lookup
-void LinkedDistribution::Manager::LookupLinkedItems(RE::TESDataHandler* const dataHandler, INI::LinkedItemsVec& rawLinkedItems)
+void           LinkedDistribution::Manager::LookupLinkedItems(RE::TESDataHandler* const dataHandler, INI::LinkedItemsVec& rawLinkedItems)
 {
 	using namespace Forms;
 
 	// TODO: Figure out templates here.
-	
 
 	for (auto& [rawForm, filterIDs, count, chance, path] : rawLinkedItems) {
 		try {

--- a/SPID/src/LinkedDistribution.cpp
+++ b/SPID/src/LinkedDistribution.cpp
@@ -1,0 +1,82 @@
+#include "LinkedDistribution.h"
+#include "FormData.h"
+
+#pragma region Parsing
+bool LinkedDistribution::INI::Parser::TryParse(const std::string& a_key, const std::string& a_value, const std::string& a_path)
+{
+	if (a_key != "LinkedItem") {
+		return false;
+	}
+
+	const auto sections = string::split(a_value, "|");
+	const auto size = sections.size();
+
+	if (size < 2) {
+		logger::warn("IGNORED: LinkedItem must have a form and at least one filter name: {} = {}"sv, a_key, a_value);
+		return false;
+	}
+
+	auto split_IDs = distribution::split_entry(sections[1]);
+
+	if (split_IDs.empty()) {
+		logger::warn("ExclusiveGroup must have at least one Form Filter : {} = {}"sv, a_key, a_value);
+		return false;
+	}
+
+	LinkedDistribution::INI::RawLinkedItem item{};
+	item.rawForm = sections[0];
+	item.path = a_path;
+
+	for (auto& IDs : split_IDs) {
+		item.rawFormFilters.MATCH.push_back(distribution::get_record(IDs));
+	}
+}
+#pragma endregion
+
+#pragma region Lookup
+void LinkedDistribution::Manager::LookupLinkedItems(RE::TESDataHandler* const dataHandler, INI::LinkedItemsVec& rawLinkedItems)
+{
+	using namespace Forms;
+
+	// TODO: Figure out templates here.
+	
+
+	for (auto& [rawForm, filterIDs, count, chance, path] : rawLinkedItems) {
+		try {
+			if (const auto form = Forms::detail::get_form(dataHandler, rawForm, path); form) {
+				/*auto& forms = linkedForms[form];
+				FormVec match{};
+
+				if (Forms::detail::formID_to_form(dataHandler, filterIDs.MATCH, match, path, false, false)) {
+					for (const auto& form : match) {
+						if (std::holds_alternative<RE::TESForm*>(form)) {
+							forms.insert(std::get<RE::TESForm*>(form));
+						}
+					}
+				}*/
+			}
+		} catch (const Lookup::UnknownFormIDException& e) {
+			buffered_logger::error("\t[{}] [0x{:X}] ({}) FAIL - formID doesn't exist", e.path, e.formID, e.modName.value_or(""));
+		} catch (const Lookup::InvalidKeywordException& e) {
+			buffered_logger::error("\t[{}] [0x{:X}] ({}) FAIL - keyword does not have a valid editorID", e.path, e.formID, e.modName.value_or(""));
+		} catch (const Lookup::KeywordNotFoundException& e) {
+			if (e.isDynamic) {
+				buffered_logger::critical("\t[{}] {} FAIL - couldn't create keyword", e.path, e.editorID);
+			} else {
+				buffered_logger::critical("\t[{}] {} FAIL - couldn't get existing keyword", e.path, e.editorID);
+			}
+		} catch (const Lookup::UnknownEditorIDException& e) {
+			buffered_logger::error("\t[{}] ({}) FAIL - editorID doesn't exist", e.path, e.editorID);
+		} catch (const Lookup::MalformedEditorIDException& e) {
+			buffered_logger::error("\t[{}] FAIL - editorID can't be empty", e.path);
+		} catch (const Lookup::InvalidFormTypeException& e) {
+			// Whitelisting is disabled, so this should not occur
+		} catch (const Lookup::UnknownPluginException& e) {
+			// Likewise, we don't expect plugin names in linked forms.
+		}
+	}
+
+	// Remove empty linked forms
+	//std::erase_if(linkedForms, [](const auto& pair) { return pair.second.empty(); });
+}
+#pragma endregion

--- a/SPID/src/LinkedDistribution.cpp
+++ b/SPID/src/LinkedDistribution.cpp
@@ -40,7 +40,7 @@ namespace LinkedDistribution
 				logger::warn("IGNORED: LinkedItem must have at least one Form Filter : {} = {}"sv, a_key, a_value);
 				return false;
 			}
-			
+
 			INI::RawLinkedItem item{};
 			item.rawForm = distribution::get_record(sections[kForm]);
 			item.path = a_path;
@@ -162,10 +162,10 @@ namespace LinkedDistribution
 				return;
 			}
 
-			 std::unordered_map<RE::TESForm*, std::vector<RE::TESForm*>> map{};
+			std::unordered_map<RE::TESForm*, std::vector<RE::TESForm*>> map{};
 
 			// Iterate through the original map
-			 for (const auto& pair : linkedForms.GetForms()) {
+			for (const auto& pair : linkedForms.GetForms()) {
 				const auto           key = pair.first;
 				const DataVec<Form>& values = pair.second;
 
@@ -214,9 +214,9 @@ namespace LinkedDistribution
 				linkedPackages,
 				linkedOutfits,
 				linkedKeywords,
-				DistributionSet::empty<RE::TESBoundObject>(), // deathItems can't be linked at the moment (only makes sense on death)
+				DistributionSet::empty<RE::TESBoundObject>(),  // deathItems can't be linked at the moment (only makes sense on death)
 				linkedFactions,
-				DistributionSet::empty<RE::BGSOutfit>(), // sleeping outfits are not supported for now due to lack of support in config's syntax.
+				DistributionSet::empty<RE::BGSOutfit>(),  // sleeping outfits are not supported for now due to lack of support in config's syntax.
 				linkedSkins
 			};
 

--- a/SPID/src/LinkedDistribution.cpp
+++ b/SPID/src/LinkedDistribution.cpp
@@ -7,83 +7,144 @@ namespace LinkedDistribution
 	using namespace Forms;
 
 #pragma region Parsing
-	bool INI::Parser::TryParse(const std::string& a_key, const std::string& a_value, const std::string& a_path)
+	namespace INI
 	{
-		if (a_key != "LinkedItem") {
-			return false;
-		}
+		enum Sections : std::uint8_t
+		{
+			kForm = 0,
+			kLinkedForms,
+			kCount,
+			kChance,
 
-		const auto sections = string::split(a_value, "|");
-		const auto size = sections.size();
+			// Minimum required sections
+			kRequired = kLinkedForms
+		};
 
-		if (size < 2) {
-			logger::warn("IGNORED: LinkedItem must have a form and at least one filter name: {} = {}"sv, a_key, a_value);
-			return false;
-		}
+		bool TryParse(const std::string& a_key, const std::string& a_value, const std::string& a_path)
+		{
+			if (a_key != "LinkedItem") {
+				return false;
+			}
 
-		auto split_IDs = distribution::split_entry(sections[1]);
+			const auto sections = string::split(a_value, "|");
+			const auto size = sections.size();
 
-		if (split_IDs.empty()) {
-			logger::warn("ExclusiveGroup must have at least one Form Filter : {} = {}"sv, a_key, a_value);
-			return false;
-		}
+			if (size <= kRequired) {
+				logger::warn("IGNORED: LinkedItem must have a form and at least one Form Filter: {} = {}"sv, a_key, a_value);
+				return false;
+			}
 
-		// TODO: Parse count and chance
+			auto split_IDs = distribution::split_entry(sections[kLinkedForms]);
 
-		INI::RawLinkedItem item{};
-		item.rawForm = sections[0];
-		item.path = a_path;
+			if (split_IDs.empty()) {
+				logger::warn("IGNORED: LinkedItem must have at least one Form Filter : {} = {}"sv, a_key, a_value);
+				return false;
+			}
+			
+			INI::RawLinkedItem item{};
+			item.rawForm = distribution::get_record(sections[kForm]);
+			item.path = a_path;
 
-		for (auto& IDs : split_IDs) {
-			item.rawFormFilters.MATCH.push_back(distribution::get_record(IDs));
+			for (auto& IDs : split_IDs) {
+				item.rawFormFilters.MATCH.push_back(distribution::get_record(IDs));
+			}
+
+			if (kCount < size) {
+				if (const auto& str = sections[kCount]; distribution::is_valid_entry(str)) {
+					if (auto countPair = string::split(str, "-"); countPair.size() > 1) {
+						auto minCount = string::to_num<Count>(countPair[0]);
+						auto maxCount = string::to_num<Count>(countPair[1]);
+
+						item.count = RandomCount(minCount, maxCount);
+					} else {
+						auto count = string::to_num<Count>(str);
+
+						item.count = RandomCount(count, count);  // create the exact match range.
+					}
+				}
+			}
+
+			if (kChance < size) {
+				if (const auto& str = sections[kChance]; distribution::is_valid_entry(str)) {
+					item.chance = string::to_num<Chance>(str);
+				}
+			}
+
+			linkedItems.push_back(item);
+
+			return true;
 		}
 	}
 #pragma endregion
 
 #pragma region Lookup
+
 	void Manager::LookupLinkedItems(RE::TESDataHandler* const dataHandler, INI::LinkedItemsVec& rawLinkedItems)
 	{
-		using namespace Forms;
+		using namespace Forms::Lookup;
 
-		// TODO: Figure out templates here.
-
-		for (auto& [rawForm, filterIDs, count, chance, path] : rawLinkedItems) {
+		for (auto& [formOrEditorID, linkedIDs, count, chance, path] : rawLinkedItems) {
 			try {
-				if (const auto form = detail::get_form(dataHandler, rawForm, path); form) {
-					/*auto& forms = linkedForms[form];
+				auto    form = detail::get_form(dataHandler, formOrEditorID, path);
 				FormVec match{};
-
-				if (detail::formID_to_form(dataHandler, filterIDs.MATCH, match, path, false, false)) {
-					for (const auto& form : match) {
-						if (std::holds_alternative<RE::TESForm*>(form)) {
-							forms.insert(std::get<RE::TESForm*>(form));
-						}
-					}
-				}*/
+				if (!detail::formID_to_form(dataHandler, linkedIDs.MATCH, match, path, false, false)) {
+					continue;
 				}
-			} catch (const Lookup::UnknownFormIDException& e) {
-				buffered_logger::error("\t[{}] [0x{:X}] ({}) FAIL - formID doesn't exist", e.path, e.formID, e.modName.value_or(""));
-			} catch (const Lookup::InvalidKeywordException& e) {
-				buffered_logger::error("\t[{}] [0x{:X}] ({}) FAIL - keyword does not have a valid editorID", e.path, e.formID, e.modName.value_or(""));
-			} catch (const Lookup::KeywordNotFoundException& e) {
+				// Add to appropriate list.
+				if (const auto keyword = form->As<RE::BGSKeyword>(); keyword) {
+					keywords.Link(keyword, match, count, chance, path);
+				} else if (const auto spell = form->As<RE::SpellItem>(); spell) {
+					spells.Link(spell, match, count, chance, path);
+				} else if (const auto perk = form->As<RE::BGSPerk>(); perk) {
+					perks.Link(perk, match, count, chance, path);
+				} else if (const auto shout = form->As<RE::TESShout>(); shout) {
+					shouts.Link(shout, match, count, chance, path);
+				} else if (const auto item = form->As<RE::TESBoundObject>(); item) {
+					items.Link(item, match, count, chance, path);
+				} else if (const auto outfit = form->As<RE::BGSOutfit>(); outfit) {
+					outfits.Link(outfit, match, count, chance, path);
+				} else if (const auto faction = form->As<RE::TESFaction>(); faction) {
+					factions.Link(faction, match, count, chance, path);
+				} else if (const auto skin = form->As<RE::TESObjectARMO>(); skin) {
+					skins.Link(skin, match, count, chance, path);
+				} else if (const auto package = form->As<RE::TESForm>(); package) {
+					auto type = package->GetFormType();
+					if (type == RE::FormType::Package || type == RE::FormType::FormList)
+						packages.Link(package, match, count, chance, path);
+				}
+			} catch (const UnknownFormIDException& e) {
+				buffered_logger::error("\t\t[{}] LinkedItem [0x{:X}] ({}) SKIP - formID doesn't exist", e.path, e.formID, e.modName.value_or(""));
+			} catch (const UnknownPluginException& e) {
+				buffered_logger::error("\t\t[{}] LinkedItem ({}) SKIP - mod cannot be found", e.path, e.modName);
+			} catch (const InvalidKeywordException& e) {
+				buffered_logger::error("\t\t[{}] LinkedItem [0x{:X}] ({}) SKIP - keyword does not have a valid editorID", e.path, e.formID, e.modName.value_or(""));
+			} catch (const KeywordNotFoundException& e) {
 				if (e.isDynamic) {
-					buffered_logger::critical("\t[{}] {} FAIL - couldn't create keyword", e.path, e.editorID);
+					buffered_logger::critical("\t\t[{}] LinkedItem {} FAIL - couldn't create keyword", e.path, e.editorID);
 				} else {
-					buffered_logger::critical("\t[{}] {} FAIL - couldn't get existing keyword", e.path, e.editorID);
+					buffered_logger::critical("\t\t[{}] LinkedItem {} FAIL - couldn't get existing keyword", e.path, e.editorID);
 				}
-			} catch (const Lookup::UnknownEditorIDException& e) {
-				buffered_logger::error("\t[{}] ({}) FAIL - editorID doesn't exist", e.path, e.editorID);
-			} catch (const Lookup::MalformedEditorIDException& e) {
-				buffered_logger::error("\t[{}] FAIL - editorID can't be empty", e.path);
-			} catch (const Lookup::InvalidFormTypeException& e) {
-				// Whitelisting is disabled, so this should not occur
-			} catch (const Lookup::UnknownPluginException& e) {
-				// Likewise, we don't expect plugin names in linked forms.
+			} catch (const UnknownEditorIDException& e) {
+				buffered_logger::error("\t\t[{}] LinkedItem ({}) SKIP - editorID doesn't exist", e.path, e.editorID);
+			} catch (const MalformedEditorIDException& e) {
+				buffered_logger::error("\t\t[{}] LinkedItem (\"\") SKIP - malformed editorID", e.path);
+			} catch (const InvalidFormTypeException& e) {
+				std::visit(overload{
+							   [&](const FormModPair& formMod) {
+								   auto& [formID, modName] = formMod;
+								   buffered_logger::error("\t\t[{}] LinkedItem [0x{:X}] ({}) SKIP - unsupported form type ({})", e.path, *formID, modName.value_or(""), RE::FormTypeToString(e.formType));
+							   },
+							   [&](std::string editorID) {
+								   buffered_logger::error("\t\t[{}] LinkedItem ({}) SKIP - unsupported form type ({})", e.path, editorID, RE::FormTypeToString(e.formType));
+							   } },
+					e.formOrEditorID);
 			}
 		}
 
 		// Remove empty linked forms
-		//std::erase_if(linkedForms, [](const auto& pair) { return pair.second.empty(); });
+		ForEachLinkedForms([&]<typename Form>(LinkedForms<Form>& forms) {
+			std::erase_if(forms.forms, [](const auto& pair) { return pair.second.empty(); });
+		});
 	}
 
 	void Manager::ForEachLinkedDistributionSet(const std::set<RE::TESForm*>& targetForms, std::function<void(DistributionSet&)> performDistribution)
@@ -97,9 +158,7 @@ namespace LinkedDistribution
 			auto& linkedPackages = LinkedFormsForForm(form, packages);
 			auto& linkedOutfits = LinkedFormsForForm(form, outfits);
 			auto& linkedKeywords = LinkedFormsForForm(form, keywords);
-			auto& linkedDeathItems = LinkedFormsForForm(form, deathItems);
 			auto& linkedFactions = LinkedFormsForForm(form, factions);
-			auto& linkedSleepOutfits = LinkedFormsForForm(form, sleepOutfits);
 			auto& linkedSkins = LinkedFormsForForm(form, skins);
 
 			DistributionSet linkedEntries{
@@ -111,9 +170,9 @@ namespace LinkedDistribution
 				linkedPackages,
 				linkedOutfits,
 				linkedKeywords,
-				linkedDeathItems,
+				DistributionSet::empty<RE::TESBoundObject>(), // deathItems can't be linked at the moment (only makes sense on death)
 				linkedFactions,
-				linkedSleepOutfits,
+				DistributionSet::empty<RE::BGSOutfit>(), // sleeping outfits are not supported for now due to lack of support in config's syntax.
 				linkedSkins
 			};
 

--- a/SPID/src/LookupConfigs.cpp
+++ b/SPID/src/LookupConfigs.cpp
@@ -322,7 +322,7 @@ namespace INI
 							continue;
 						}
 
-						if (LinkedDistribution::INI::Parser::TryParse(key.pItem, entry, truncatedPath)) {
+						if (LinkedDistribution::INI::TryParse(key.pItem, entry, truncatedPath)) {
 							continue;
 						}
 

--- a/SPID/src/LookupConfigs.cpp
+++ b/SPID/src/LookupConfigs.cpp
@@ -1,4 +1,5 @@
 #include "LookupConfigs.h"
+#include "LinkedDistribution.h"
 
 namespace INI
 {
@@ -55,13 +56,8 @@ namespace INI
 			const auto sections = string::split(a_value, "|");
 			const auto size = sections.size();
 
-			if (size == 0) {
-				logger::warn("IGNORED: ExclusiveGroup must have a name: {} = {}"sv, a_key, a_value);
-				return std::nullopt;
-			}
-
-			if (size == 1) {
-				logger::warn("IGNORED: ExclusiveGroup must have at least one filter name: {} = {}"sv, a_key, a_value);
+			if (size < 2) {
+				logger::warn("IGNORED: ExclusiveGroup must have a name and at least one Form Filter: {} = {}"sv, a_key, a_value);
 				return std::nullopt;
 			}
 
@@ -323,6 +319,10 @@ namespace INI
 					try {
 						if (const auto group = detail::parse_exclusive_group(key.pItem, entry, truncatedPath); group) {
 							exclusiveGroups.emplace_back(*group);
+							continue;
+						}
+
+						if (LinkedDistribution::INI::Parser::TryParse(key.pItem, entry, truncatedPath)) {
 							continue;
 						}
 

--- a/SPID/src/LookupForms.cpp
+++ b/SPID/src/LookupForms.cpp
@@ -85,35 +85,7 @@ void LookupLinkedItems(RE::TESDataHandler* const dataHandler)
 
 void LogLinkedItemsLookup()
 {
-	using namespace LinkedDistribution;
-
-	logger::info("{:*^50}", "LINKED ITEMS");
-
-	Manager::GetSingleton()->ForEachLinkedForms([]<typename Form>(const LinkedForms<Form>& linkedForms) {
-		if (linkedForms.GetForms().empty()) {
-			return;
-		}
-		const auto& recordName = RECORD::add[linkedForms.GetType()];
-		logger::info("Linked {}s: ", recordName);
-
-		for (const auto& [form, linkedItems] : linkedForms.GetForms()) {
-			logger::info("\t{}", describe(form));
-
-			const auto lastItemIndex = linkedItems.size() - 1;
-			for (int i = 0; i < lastItemIndex; ++i) {
-				const auto& linkedItem = linkedItems[i];
-				logger::info("\t├─── {}", describe(linkedItem.form));
-			}
-			const auto& lastLinkedItem = linkedItems[lastItemIndex];
-			logger::info("\t└─── {}", describe(lastLinkedItem.form));
-		}
-	});
-
-	// Clear INI once lookup is done
-	LinkedDistribution::INI::linkedItems.clear();
-
-	// Clear logger's buffer to free some memory :)
-	buffered_logger::clear();
+	LinkedDistribution::Manager::GetSingleton()->LogLinkedItemsLookup();
 }
 
 bool Lookup::LookupForms()

--- a/SPID/src/LookupForms.cpp
+++ b/SPID/src/LookupForms.cpp
@@ -1,8 +1,8 @@
 #include "LookupForms.h"
 #include "ExclusiveGroups.h"
-#include "LinkedDistribution.h"
 #include "FormData.h"
 #include "KeywordDependencies.h"
+#include "LinkedDistribution.h"
 
 bool LookupDistributables(RE::TESDataHandler* const dataHandler)
 {


### PR DESCRIPTION
# Summary

_Linked Items_ allow users to reduce number of repetitive filters, by linking items to other forms. Ordering and other distribution rules are unaffected by _Linked Items_. When a parent entry is distributed, all linked entries are automatically distributed as well to the same NPC. Linked items may have Count (supports [Random Count](https://github.com/powerof3/Spell-Perk-Item-Distributor/pull/20)) and random chance.

# Use Case

For example, when people want to distribute ranged weapons with some complex conditions and also provide specific ammo that should go with it.

```ini
Item = CoolBow|ComplexFiltering
Item = AmmoForCoolBow|ComplexFiltering|20
```

Notice how we had to duplicate all filters. But that's not even the worst part 🙂 things become much worse when given `CoolBow` has a random chance of being distributed. The only option for us here is once again abuse `Keyword` to achieve desired effect:

```ini
Keyword = GetsCoolBow|ComplexFiltering|NONE|50

Item = CoolBow|GetsCoolBow
Item = AmmoForCoolBow|GetsCoolBow|20
```

It works, but it's ugly 🙂 and limited.

Other than cluttering keywords this approach also can't reliably support add-ons. So, if there are some other mods that would like to distribute either `CoolBow` or ammo for it they'd probably have to implement the same workaround.

This is where _Linked Items_ come to the rescue 😄 as a mod author you only care about providing some ammo for your bow.
So, you'd only want to do this:
```ini
Item = CoolBow|ComplexFiltering|NONE|50

LinkedItem = AmmoForCoolBow|CoolBow|20
```
and we're done. Whenever `CoolBow` will be distributed NPC will also receive 20 `AmmoForCoolBow` arrows. We no longer need to clutter Keywords or duplicate filters.

And to top it off we can combine this feature with [Exclusive Groups](https://github.com/powerof3/Spell-Perk-Item-Distributor/pull/19) to be able to distribute one random type of ammo for each bow:

```ini
Item = CoolBow|ComplexFiltering|NONE|50

LinkedItem = AmmoForCoolBow|CoolBow|20|35
LinkedItem = BetterAmmoForCoolBow|CoolBow|15|50
LinkedItem = TheBestAmmoForCoolBow|CoolBow|10

ExclusiveGroup = OneTypeOfAmmo|AmmoForCoolBow,BetterAmmoForCoolBow,TheBestAmmoForCoolBow
```

0 keywords required 😄 

---

# Syntax

Familiar syntax was preserved.

```ini
LinkedItem = LinkedForm|ParentForm,ParentForm2,...|COUNT|CHANCE
```

### Defining _Linked Item_

To define a new _Linked Item_ we only need to provide a form to be linked and at least one form (FormID/EditorID) to link to in the second section:

```ini
LinkedItem = MyItem|Form1,Form2
```
> Now `MyItem` will be linked to distributions of `Form1` and `Form2`

### Specifying count of _Linked Items_

Similarly to common distributable items when appropriate we can specify a count of linked items to be distributed:
```ini
LinkedItem = IronArrow|Form3|50
```
> Now 50 `IronArrow`s will be linked to `Form3`

### _Linked Item_ can also have an additional random chance to be distributed:

```ini
LinkedItem = IronArrow|Form3|50|33
```
> Now 50 `IronArrow`s will be linked to `Form3` and will be distributed along with `Form3` with a 33% chance.

P.S. This description probably will be converted into an article for SPID page and be the beginning of extensive documentation for SPID 😆 