### PR TITLE
Type inferring for Linked Forms and Linking of DeathItems

### DIFF
--- a/SPID/include/Distribute.h
+++ b/SPID/include/Distribute.h
@@ -235,6 +235,8 @@ namespace Distribute
 	}
 #pragma endregion
 
-	void Distribute(NPCData& a_npcData, const PCLevelMult::Input& a_input);
-	void Distribute(NPCData& a_npcData, bool a_onlyLeveledEntries);
+	void Distribute(NPCData& npcData, const PCLevelMult::Input& input);
+	void Distribute(NPCData& npcData, bool onlyLeveledEntries);
+
+	void DistributeDeathItems(NPCData& npcData, const PCLevelMult::Input& input);
 }

--- a/SPID/include/FormData.h
+++ b/SPID/include/FormData.h
@@ -524,7 +524,7 @@ Forms::DataVec<Form>& Forms::Distributables<Form>::GetForms(bool a_onlyLevelEntr
 	return forms;
 }
 
-template<class Form>
+template <class Form>
 void Forms::Distributables<Form>::LookupForm(RE::TESDataHandler* a_dataHandler, INI::Data& rawForm)
 {
 	Forms::LookupGenericForm<Form>(a_dataHandler, rawForm, [&](Form* form, auto& idxOrCount, auto& filters, std::string& path) {

--- a/SPID/include/FormData.h
+++ b/SPID/include/FormData.h
@@ -217,7 +217,7 @@ namespace Forms
 
 								   form = as_form(anyForm);
 								   if (!form) {
-									   throw MismatchingFormTypeException(anyForm->GetFormType(), Form::FORMTYPE, FormModPair{*formID, modName}, path);
+									   throw MismatchingFormTypeException(anyForm->GetFormType(), Form::FORMTYPE, FormModPair{ *formID, modName }, path);
 								   }
 
 								   if constexpr (std::is_same_v<Form, RE::BGSKeyword>) {

--- a/SPID/include/LinkedDistribution.h
+++ b/SPID/include/LinkedDistribution.h
@@ -7,12 +7,12 @@ namespace LinkedDistribution
 {
 	namespace INI
 	{
-		struct RawLinkedItem
+		struct RawLinkedForm
 		{
-			FormOrEditorID rawForm{};
+			FormOrEditorID formOrEditorID{};
 
-			/// Raw filters in RawLinkedItem only use MATCH, there is no meaning for ALL or NOT, so they are ignored.
-			Filters<FormOrEditorID> rawFormFilters{};
+			/// Raw filters in RawLinkedForm only use MATCH, there is no meaning for ALL or NOT, so they are ignored.
+			Filters<FormOrEditorID> formIDs{};
 
 			RandomCount count{ 1, 1 };
 			Chance      chance{ 100 };
@@ -20,34 +20,52 @@ namespace LinkedDistribution
 			std::string path{};
 		};
 
-		using LinkedItemsVec = std::vector<RawLinkedItem>;
+		using LinkedFormsVec = std::vector<RawLinkedForm>;
+		using LinkedFormsConfig = std::unordered_map<RECORD::TYPE, LinkedFormsVec>;
 
-		inline LinkedItemsVec linkedItems{};
+		inline LinkedFormsConfig linkedForms{};
 
+		/// <summary>
+		/// Checks whether given entry is a linked form and attempts to parse it.
+		/// </summary>
+		/// <returns>true if given entry was a linked form. Note that returned value doesn't represent whether or parsing was successful.</returns>
 		bool TryParse(const std::string& a_key, const std::string& a_value, const std::string& a_path);
 	}
 
-	using namespace Forms;
 
 	class Manager;
+	
+	template<class Form>
+	struct LinkedForms;
+
+	namespace detail
+	{
+		template <class Form = RE::TESForm>
+		Form* LookupLinkedForm(RE::TESDataHandler* const dataHandler, INI::RawLinkedForm& rawForm);
+	}
+
+	using namespace Forms;
 
 	template <class Form>
 	struct LinkedForms
 	{
 		friend Manager;  // allow Manager to later modify forms directly.
+		friend Form* detail::LookupLinkedForm(RE::TESDataHandler* const, INI::RawLinkedForm&);
 
-		using Map = std::unordered_map<RE::TESForm*, DataVec<Form>>;
+		using FormsMap = std::unordered_map<RE::TESForm*, DataVec<Form>>;
 
 		LinkedForms(RECORD::TYPE type) :
 			type(type)
 		{}
 
 		RECORD::TYPE GetType() const { return type; }
-		const Map&   GetForms() const { return forms; }
+		const FormsMap& GetForms() const { return forms; }
+
+		void LookupForms(RE::TESDataHandler* const dataHandler, INI::LinkedFormsVec& rawLinkedForms);
 
 	private:
 		RECORD::TYPE type;
-		Map          forms{};
+		FormsMap     forms{};
 
 		void Link(Form* form, const FormVec& linkedForms, const RandomCount& count, const Chance& chance, const std::string& path);
 	};
@@ -58,13 +76,13 @@ namespace LinkedDistribution
 		/// <summary>
 		/// Does a forms lookup similar to what Filters do.
 		///
-		/// As a result this method configures Manager with discovered valid linked items.
+		/// As a result this method configures Manager with discovered valid linked forms.
 		/// </summary>
 		/// <param name="dataHandler">A DataHandler that will perform the actual lookup.</param>
-		/// <param name="rawLinkedDistribution">A raw linked item entries that should be processed.</param>
-		void LookupLinkedItems(RE::TESDataHandler* const dataHandler, INI::LinkedItemsVec& rawLinkedItems = INI::linkedItems);
+		/// <param name="rawLinkedDistribution">A raw linked form entries that should be processed.</param>
+		void LookupLinkedForms(RE::TESDataHandler* const dataHandler, INI::LinkedFormsConfig& rawLinkedForms = INI::linkedForms);
 
-		void LogLinkedItemsLookup();
+		void LogLinkedFormsLookup();
 
 		/// <summary>
 		/// Calculates DistributionSet for each linked form and calls a callback for each of them.
@@ -93,10 +111,58 @@ namespace LinkedDistribution
 		/// Iterates over each type of LinkedForms and calls a callback with each of them.
 		/// </summary>
 		template <typename Func, typename... Args>
-		void ForEachLinkedForms(Func&& func, const Args&&... args);
+		void ForEachLinkedForms(Func&& func, Args&&... args);
 	};
 
 #pragma region Implementation
+
+	template <class Form>
+	Form* detail::LookupLinkedForm(RE::TESDataHandler* const dataHandler, INI::RawLinkedForm& rawForm)
+	{
+		using namespace Forms::Lookup;
+
+		try {
+			return Forms::detail::get_form<Form>(dataHandler, rawForm.formOrEditorID, rawForm.path);
+		} catch (const UnknownFormIDException& e) {
+			buffered_logger::error("\t\t[{}] LinkedForm [0x{:X}] ({}) SKIP - formID doesn't exist", e.path, e.formID, e.modName.value_or(""));
+		} catch (const UnknownPluginException& e) {
+			buffered_logger::error("\t\t[{}] LinkedForm ({}) SKIP - mod cannot be found", e.path, e.modName);
+		} catch (const InvalidKeywordException& e) {
+			buffered_logger::error("\t\t[{}] LinkedForm [0x{:X}] ({}) SKIP - keyword does not have a valid editorID", e.path, e.formID, e.modName.value_or(""));
+		} catch (const KeywordNotFoundException& e) {
+			if (e.isDynamic) {
+				buffered_logger::critical("\t\t[{}] LinkedForm {} FAIL - couldn't create keyword", e.path, e.editorID);
+			} else {
+				buffered_logger::critical("\t\t[{}] LinkedForm {} FAIL - couldn't get existing keyword", e.path, e.editorID);
+			}
+		} catch (const UnknownEditorIDException& e) {
+			buffered_logger::error("\t\t[{}] LinkedForm ({}) SKIP - editorID doesn't exist", e.path, e.editorID);
+		} catch (const MalformedEditorIDException& e) {
+			buffered_logger::error("\t\t[{}] LinkedForm (\"\") SKIP - malformed editorID", e.path);
+		} catch (const MismatchingFormTypeException& e) {
+			std::visit(overload{
+						   [&](const FormModPair& formMod) {
+							   auto& [formID, modName] = formMod;
+							   buffered_logger::error("\t\t[{}] LinkedForm [0x{:X}] ({}) SKIP - mismatching form type (expected: {}, actual: {})", e.path, *formID, modName.value_or(""), RE::FormTypeToString(e.expectedFformType), RE::FormTypeToString(e.actualFormType));
+						   },
+						   [&](std::string editorID) {
+							   buffered_logger::error("\t\t[{}] LinkedForm ({}) SKIP - mismatching form type (expected: {}, actual: {})", e.path, editorID, RE::FormTypeToString(e.expectedFformType), RE::FormTypeToString(e.actualFormType));
+						   } },
+				e.formOrEditorID);
+		} catch (const InvalidFormTypeException& e) {
+			std::visit(overload{
+						   [&](const FormModPair& formMod) {
+							   auto& [formID, modName] = formMod;
+							   buffered_logger::error("\t\t[{}] LinkedForm [0x{:X}] ({}) SKIP - unsupported form type ({})", e.path, *formID, modName.value_or(""), RE::FormTypeToString(e.formType));
+						   },
+						   [&](std::string editorID) {
+							   buffered_logger::error("\t\t[{}] LinkedForm ({}) SKIP - unsupported form type ({})", e.path, editorID, RE::FormTypeToString(e.formType));
+						   } },
+				e.formOrEditorID);
+		}
+		return nullptr;
+	}
+
 	template <class Form>
 	DataVec<Form>& Manager::LinkedFormsForForm(RE::TESForm* form, LinkedForms<Form>& linkedForms) const
 	{
@@ -109,7 +175,7 @@ namespace LinkedDistribution
 	}
 
 	template <typename Func, typename... Args>
-	void Manager::ForEachLinkedForms(Func&& func, const Args&&... args)
+	void Manager::ForEachLinkedForms(Func&& func, Args&&... args)
 	{
 		func(keywords, std::forward<Args>(args)...);
 		func(spells, std::forward<Args>(args)...);
@@ -124,12 +190,25 @@ namespace LinkedDistribution
 	}
 
 	template <class Form>
+	void LinkedForms<Form>::LookupForms(RE::TESDataHandler* const dataHandler, INI::LinkedFormsVec& rawLinkedForms)
+	{
+		for (auto& rawForm : rawLinkedForms) {
+			auto form = detail::LookupLinkedForm<Form>(dataHandler, rawForm);
+			auto& [formID, parentFormIDs, count, chance, path] = rawForm;
+			FormVec parentForms{};
+			if (Forms::detail::formID_to_form(dataHandler, parentFormIDs.MATCH, parentForms, path, false, false)) {
+				Link(form, parentForms, count, chance, path);
+			}
+		}
+	}
+
+	template <class Form>
 	void LinkedForms<Form>::Link(Form* form, const FormVec& linkedForms, const RandomCount& count, const Chance& chance, const std::string& path)
 	{
 		for (const auto& linkedForm : linkedForms) {
 			if (std::holds_alternative<RE::TESForm*>(linkedForm)) {
 				auto& distributableForms = forms[std::get<RE::TESForm*>(linkedForm)];
-				// Note that we don't use Data.index here, as these linked items doesn't have any leveled filters
+				// Note that we don't use Data.index here, as these linked forms don't have any leveled filters
 				// and as such do not to track their index.
 				distributableForms.emplace_back(0, form, count, FilterData({}, {}, {}, {}, chance), path);
 			}

--- a/SPID/include/LinkedDistribution.h
+++ b/SPID/include/LinkedDistribution.h
@@ -32,6 +32,8 @@ namespace LinkedDistribution
 		bool TryParse(const std::string& a_key, const std::string& a_value, const std::string& a_path);
 	}
 
+	using namespace Forms;
+
 	class Manager;
 
 	template <class Form>
@@ -42,9 +44,7 @@ namespace LinkedDistribution
 		template <class Form = RE::TESForm>
 		Form* LookupLinkedForm(RE::TESDataHandler* const dataHandler, INI::RawLinkedForm& rawForm);
 	}
-
-	using namespace Forms;
-
+	
 	template <class Form>
 	struct LinkedForms
 	{

--- a/SPID/include/LinkedDistribution.h
+++ b/SPID/include/LinkedDistribution.h
@@ -14,7 +14,7 @@ namespace LinkedDistribution
 			/// Raw filters in RawLinkedForm only use MATCH, there is no meaning for ALL or NOT, so they are ignored.
 			Filters<FormOrEditorID> formIDs{};
 
-			RandomCount count{ 1, 1 };
+			IndexOrCount idxOrCount { RandomCount(1, 1) };
 			Chance      chance{ 100 };
 
 			std::string path{};
@@ -67,7 +67,7 @@ namespace LinkedDistribution
 		RECORD::TYPE type;
 		FormsMap     forms{};
 
-		void Link(Form* form, const FormVec& linkedForms, const RandomCount& count, const Chance& chance, const std::string& path);
+		void Link(Form* form, const FormVec& linkedForms, const IndexOrCount& idxOrCount, const Chance& chance, const std::string& path);
 	};
 
 	class Manager : public ISingleton<Manager>
@@ -99,10 +99,12 @@ namespace LinkedDistribution
 		LinkedForms<RE::SpellItem>      spells{ RECORD::kSpell };
 		LinkedForms<RE::BGSPerk>        perks{ RECORD::kPerk };
 		LinkedForms<RE::TESBoundObject> items{ RECORD::kItem };
+		LinkedForms<RE::TESBoundObject> deathItems{ RECORD::kDeathItem };
 		LinkedForms<RE::TESShout>       shouts{ RECORD::kShout };
 		LinkedForms<RE::TESLevSpell>    levSpells{ RECORD::kLevSpell };
 		LinkedForms<RE::TESForm>        packages{ RECORD::kPackage };
 		LinkedForms<RE::BGSOutfit>      outfits{ RECORD::kOutfit };
+		LinkedForms<RE::BGSOutfit>      sleepingOutfits{ RECORD::kSleepOutfit };
 		LinkedForms<RE::BGSKeyword>     keywords{ RECORD::kKeyword };
 		LinkedForms<RE::TESFaction>     factions{ RECORD::kFaction };
 		LinkedForms<RE::TESObjectARMO>  skins{ RECORD::kSkin };
@@ -183,7 +185,9 @@ namespace LinkedDistribution
 		func(perks, std::forward<Args>(args)...);
 		func(shouts, std::forward<Args>(args)...);
 		func(items, std::forward<Args>(args)...);
+		func(deathItems, std::forward<Args>(args)...);
 		func(outfits, std::forward<Args>(args)...);
+		func(sleepingOutfits, std::forward<Args>(args)...);
 		func(factions, std::forward<Args>(args)...);
 		func(packages, std::forward<Args>(args)...);
 		func(skins, std::forward<Args>(args)...);
@@ -203,14 +207,14 @@ namespace LinkedDistribution
 	}
 
 	template <class Form>
-	void LinkedForms<Form>::Link(Form* form, const FormVec& linkedForms, const RandomCount& count, const Chance& chance, const std::string& path)
+	void LinkedForms<Form>::Link(Form* form, const FormVec& linkedForms, const IndexOrCount& idxOrCount, const Chance& chance, const std::string& path)
 	{
 		for (const auto& linkedForm : linkedForms) {
 			if (std::holds_alternative<RE::TESForm*>(linkedForm)) {
 				auto& distributableForms = forms[std::get<RE::TESForm*>(linkedForm)];
 				// Note that we don't use Data.index here, as these linked forms don't have any leveled filters
 				// and as such do not to track their index.
-				distributableForms.emplace_back(0, form, count, FilterData({}, {}, {}, {}, chance), path);
+				distributableForms.emplace_back(0, form, idxOrCount, FilterData({}, {}, {}, {}, chance), path);
 			}
 		}
 	}

--- a/SPID/include/LinkedDistribution.h
+++ b/SPID/include/LinkedDistribution.h
@@ -14,8 +14,8 @@ namespace LinkedDistribution
 			/// Raw filters in RawLinkedForm only use MATCH, there is no meaning for ALL or NOT, so they are ignored.
 			Filters<FormOrEditorID> formIDs{};
 
-			IndexOrCount idxOrCount { RandomCount(1, 1) };
-			Chance      chance{ 100 };
+			IndexOrCount idxOrCount{ RandomCount(1, 1) };
+			Chance       chance{ 100 };
 
 			std::string path{};
 		};
@@ -32,10 +32,9 @@ namespace LinkedDistribution
 		bool TryParse(const std::string& a_key, const std::string& a_value, const std::string& a_path);
 	}
 
-
 	class Manager;
-	
-	template<class Form>
+
+	template <class Form>
 	struct LinkedForms;
 
 	namespace detail
@@ -58,7 +57,7 @@ namespace LinkedDistribution
 			type(type)
 		{}
 
-		RECORD::TYPE GetType() const { return type; }
+		RECORD::TYPE    GetType() const { return type; }
 		const FormsMap& GetForms() const { return forms; }
 
 		void LookupForms(RE::TESDataHandler* const dataHandler, INI::LinkedFormsVec& rawLinkedForms);

--- a/SPID/include/LinkedDistribution.h
+++ b/SPID/include/LinkedDistribution.h
@@ -44,7 +44,7 @@ namespace LinkedDistribution
 		template <class Form = RE::TESForm>
 		Form* LookupLinkedForm(RE::TESDataHandler* const dataHandler, INI::RawLinkedForm& rawForm);
 	}
-	
+
 	template <class Form>
 	struct LinkedForms
 	{

--- a/SPID/include/LinkedDistribution.h
+++ b/SPID/include/LinkedDistribution.h
@@ -91,6 +91,15 @@ namespace LinkedDistribution
 		/// <param name="callback">A callback to be called with each DistributionSet. This is supposed to do the actual distribution.</param>
 		void ForEachLinkedDistributionSet(const std::set<RE::TESForm*>& linkedForms, std::function<void(DistributionSet&)> callback);
 
+		/// <summary>
+		/// Calculates DistributionSet with only DeathItems for each linked form and calls a callback for each of them.
+		/// This method is suitable for distributing items on death.
+		/// </summary>
+		/// <param name="linkedForms">A set of forms for which distribution sets should be calculated.
+		///							  This is typically distributed forms accumulated during first distribution pass.</param>
+		/// <param name="callback">A callback to be called with each DistributionSet. This is supposed to do the actual distribution.</param>
+		void ForEachLinkedDeathDistributionSet(const std::set<RE::TESForm*>& linkedForms, std::function<void(DistributionSet&)> callback);
+
 	private:
 		template <class Form>
 		DataVec<Form>& LinkedFormsForForm(RE::TESForm* form, LinkedForms<Form>& linkedForms) const;
@@ -103,7 +112,7 @@ namespace LinkedDistribution
 		LinkedForms<RE::TESLevSpell>    levSpells{ RECORD::kLevSpell };
 		LinkedForms<RE::TESForm>        packages{ RECORD::kPackage };
 		LinkedForms<RE::BGSOutfit>      outfits{ RECORD::kOutfit };
-		LinkedForms<RE::BGSOutfit>      sleepingOutfits{ RECORD::kSleepOutfit };
+		LinkedForms<RE::BGSOutfit>      sleepOutfits{ RECORD::kSleepOutfit };
 		LinkedForms<RE::BGSKeyword>     keywords{ RECORD::kKeyword };
 		LinkedForms<RE::TESFaction>     factions{ RECORD::kFaction };
 		LinkedForms<RE::TESObjectARMO>  skins{ RECORD::kSkin };
@@ -186,7 +195,7 @@ namespace LinkedDistribution
 		func(items, std::forward<Args>(args)...);
 		func(deathItems, std::forward<Args>(args)...);
 		func(outfits, std::forward<Args>(args)...);
-		func(sleepingOutfits, std::forward<Args>(args)...);
+		func(sleepOutfits, std::forward<Args>(args)...);
 		func(factions, std::forward<Args>(args)...);
 		func(packages, std::forward<Args>(args)...);
 		func(skins, std::forward<Args>(args)...);

--- a/SPID/include/LookupConfigs.h
+++ b/SPID/include/LookupConfigs.h
@@ -4,7 +4,12 @@ namespace RECORD
 {
 	enum TYPE
 	{
-		kSpell = 0,
+		/// <summary>
+		/// A generic form type that requries type inference.
+		/// </summary>
+		kForm = 0,
+
+		kSpell,
 		kPerk,
 		kItem,
 		kShout,
@@ -20,8 +25,35 @@ namespace RECORD
 		kTotal
 	};
 
-	inline constexpr std::array add{ "Spell"sv, "Perk"sv, "Item"sv, "Shout"sv, "LevSpell"sv, "Package"sv, "Outfit"sv, "Keyword"sv, "DeathItem"sv, "Faction"sv, "SleepOutfit"sv, "Skin"sv };
-	inline constexpr std::array remove{ "-Spell"sv, "-Perk"sv, "-Item"sv, "-Shout"sv, "-LevSpell"sv, "-Package"sv, "-Outfit"sv, "-Keyword"sv, "-DeathItem"sv, "-Faction"sv, "-SleepOutfit"sv, "-Skin"sv };
+	namespace detail
+	{
+		inline static constexpr std::array add{
+			"Form"sv,
+			"Spell"sv,
+			"Perk"sv,
+			"Item"sv,
+			"Shout"sv,
+			"LevSpell"sv,
+			"Package"sv,
+			"Outfit"sv,
+			"Keyword"sv,
+			"DeathItem"sv,
+			"Faction"sv,
+			"SleepOutfit"sv,
+			"Skin"sv
+		};
+	}
+
+	inline constexpr std::string_view GetTypeName(const TYPE aType) 
+	{
+		return detail::add.at(aType);
+	}
+
+	inline constexpr TYPE GetType(const std::string& aType) 
+	{
+		using namespace detail;
+		return static_cast<TYPE>(std::distance(add.begin(), std::find(add.begin(), add.end(), aType)));
+	}
 }
 
 namespace INI

--- a/SPID/include/LookupConfigs.h
+++ b/SPID/include/LookupConfigs.h
@@ -60,6 +60,12 @@ namespace RECORD
 		using namespace detail;
 		return static_cast<TYPE>(std::distance(add.begin(), std::find(add.begin(), add.end(), aType)));
 	}
+
+	inline constexpr TYPE GetType(const char* aType)
+	{
+		using namespace detail;
+		return static_cast<TYPE>(std::distance(add.begin(), std::find(add.begin(), add.end(), aType)));
+	}
 }
 
 namespace INI
@@ -101,7 +107,7 @@ namespace INI
 	using DataVec = std::vector<Data>;
 	using ExclusiveGroupsVec = std::vector<RawExclusiveGroup>;
 
-	inline StringMap<DataVec> configs{};
+	inline Map<RECORD::TYPE, DataVec> configs{};
 
 	/// <summary>
 	/// A list of RawExclusiveGroups that will be processed along with configs.

--- a/SPID/include/LookupConfigs.h
+++ b/SPID/include/LookupConfigs.h
@@ -44,12 +44,12 @@ namespace RECORD
 		};
 	}
 
-	inline constexpr std::string_view GetTypeName(const TYPE aType) 
+	inline constexpr std::string_view GetTypeName(const TYPE aType)
 	{
 		return detail::add.at(aType);
 	}
 
-	inline constexpr TYPE GetType(const std::string& aType) 
+	inline constexpr TYPE GetType(const std::string& aType)
 	{
 		using namespace detail;
 		return static_cast<TYPE>(std::distance(add.begin(), std::find(add.begin(), add.end(), aType)));

--- a/SPID/include/LookupConfigs.h
+++ b/SPID/include/LookupConfigs.h
@@ -54,6 +54,12 @@ namespace RECORD
 		using namespace detail;
 		return static_cast<TYPE>(std::distance(add.begin(), std::find(add.begin(), add.end(), aType)));
 	}
+
+	inline constexpr TYPE GetType(const std::string_view& aType)
+	{
+		using namespace detail;
+		return static_cast<TYPE>(std::distance(add.begin(), std::find(add.begin(), add.end(), aType)));
+	}
 }
 
 namespace INI

--- a/SPID/src/Distribute.cpp
+++ b/SPID/src/Distribute.cpp
@@ -228,12 +228,11 @@ namespace Distribute
 			Forms::DistributionSet::empty<RE::BGSOutfit>(),
 			Forms::DistributionSet::empty<RE::TESObjectARMO>()
 		};
-		
+
 		detail::distribute(npcData, input, entries, &distributedForms);
 		// TODO: We can now log per-NPC distributed forms.
 
 		if (!distributedForms.empty()) {
-
 			LinkedDistribution::Manager::GetSingleton()->ForEachLinkedDeathDistributionSet(distributedForms, [&](Forms::DistributionSet& set) {
 				detail::distribute(npcData, input, set, nullptr);  // TODO: Accumulate forms here? to log what was distributed.
 			});

--- a/SPID/src/Distribute.cpp
+++ b/SPID/src/Distribute.cpp
@@ -158,52 +158,85 @@ namespace Distribute
 					return false;
 				},
 				accumulatedForms);
+
+			for_each_form<RE::TESBoundObject>(
+				npcData, forms.deathItems, input, [&](auto* deathItem, IndexOrCount idxOrCount) {
+					auto count = std::get<RandomCount>(idxOrCount);
+
+					detail::add_item(npcData.GetActor(), deathItem, count.GetRandom());
+					return true;
+				},
+				accumulatedForms);
 		}
 	}
 
-	// This only does one-level linking. So that linked entries won't trigger another level of distribution.
-	void DistributeLinkedEntries(NPCData& npcData, const PCLevelMult::Input& input, const std::set<RE::TESForm*>& forms)
+	void Distribute(NPCData& npcData, const PCLevelMult::Input& input)
 	{
-		LinkedDistribution::Manager::GetSingleton()->ForEachLinkedDistributionSet(forms, [&](Forms::DistributionSet& set) {
-			detail::distribute(npcData, input, set, nullptr);  // TODO: Accumulate forms here?
-		});
-	}
-
-	void Distribute(NPCData& a_npcData, const PCLevelMult::Input& a_input)
-	{
-		if (a_input.onlyPlayerLevelEntries && PCLevelMult::Manager::GetSingleton()->HasHitLevelCap(a_input)) {
+		if (input.onlyPlayerLevelEntries && PCLevelMult::Manager::GetSingleton()->HasHitLevelCap(input)) {
 			return;
 		}
 
-		// TODO: Figure out how to distribute only death items perhaps?
 		Forms::DistributionSet entries{
-			Forms::spells.GetForms(a_input.onlyPlayerLevelEntries),
-			Forms::perks.GetForms(a_input.onlyPlayerLevelEntries),
-			Forms::items.GetForms(a_input.onlyPlayerLevelEntries),
-			Forms::shouts.GetForms(a_input.onlyPlayerLevelEntries),
-			Forms::levSpells.GetForms(a_input.onlyPlayerLevelEntries),
-			Forms::packages.GetForms(a_input.onlyPlayerLevelEntries),
-			Forms::outfits.GetForms(a_input.onlyPlayerLevelEntries),
-			Forms::keywords.GetForms(a_input.onlyPlayerLevelEntries),
+			Forms::spells.GetForms(input.onlyPlayerLevelEntries),
+			Forms::perks.GetForms(input.onlyPlayerLevelEntries),
+			Forms::items.GetForms(input.onlyPlayerLevelEntries),
+			Forms::shouts.GetForms(input.onlyPlayerLevelEntries),
+			Forms::levSpells.GetForms(input.onlyPlayerLevelEntries),
+			Forms::packages.GetForms(input.onlyPlayerLevelEntries),
+			Forms::outfits.GetForms(input.onlyPlayerLevelEntries),
+			Forms::keywords.GetForms(input.onlyPlayerLevelEntries),
 			Forms::DistributionSet::empty<RE::TESBoundObject>(),  // deathItems are only processed on... well, death.
-			Forms::factions.GetForms(a_input.onlyPlayerLevelEntries),
-			Forms::sleepOutfits.GetForms(a_input.onlyPlayerLevelEntries),
-			Forms::skins.GetForms(a_input.onlyPlayerLevelEntries)
+			Forms::factions.GetForms(input.onlyPlayerLevelEntries),
+			Forms::sleepOutfits.GetForms(input.onlyPlayerLevelEntries),
+			Forms::skins.GetForms(input.onlyPlayerLevelEntries)
 		};
 
 		std::set<RE::TESForm*> distributedForms{};
 
-		detail::distribute(a_npcData, a_input, entries, &distributedForms);
+		detail::distribute(npcData, input, entries, &distributedForms);
 		// TODO: We can now log per-NPC distributed forms.
 
 		if (!distributedForms.empty()) {
-			DistributeLinkedEntries(a_npcData, a_input, distributedForms);
+			// This only does one-level linking. So that linked entries won't trigger another level of distribution.
+			LinkedDistribution::Manager::GetSingleton()->ForEachLinkedDistributionSet(distributedForms, [&](Forms::DistributionSet& set) {
+				detail::distribute(npcData, input, set, nullptr);  // TODO: Accumulate forms here? to log what was distributed.
+			});
 		}
 	}
 
-	void Distribute(NPCData& a_npcData, bool a_onlyLeveledEntries)
+	void Distribute(NPCData& npcData, bool onlyLeveledEntries)
 	{
-		const auto input = PCLevelMult::Input{ a_npcData.GetActor(), a_npcData.GetNPC(), a_onlyLeveledEntries };
-		Distribute(a_npcData, input);
+		const auto input = PCLevelMult::Input{ npcData.GetActor(), npcData.GetNPC(), onlyLeveledEntries };
+		Distribute(npcData, input);
+	}
+
+	void DistributeDeathItems(NPCData& npcData, const PCLevelMult::Input& input)
+	{
+		std::set<RE::TESForm*> distributedForms{};
+
+		Forms::DistributionSet entries{
+			Forms::DistributionSet::empty<RE::SpellItem>(),
+			Forms::DistributionSet::empty<RE::BGSPerk>(),
+			Forms::DistributionSet::empty<RE::TESBoundObject>(),
+			Forms::DistributionSet::empty<RE::TESShout>(),
+			Forms::DistributionSet::empty<RE::TESLevSpell>(),
+			Forms::DistributionSet::empty<RE::TESForm>(),
+			Forms::DistributionSet::empty<RE::BGSOutfit>(),
+			Forms::DistributionSet::empty<RE::BGSKeyword>(),
+			Forms::deathItems.GetForms(input.onlyPlayerLevelEntries),
+			Forms::DistributionSet::empty<RE::TESFaction>(),
+			Forms::DistributionSet::empty<RE::BGSOutfit>(),
+			Forms::DistributionSet::empty<RE::TESObjectARMO>()
+		};
+		
+		detail::distribute(npcData, input, entries, &distributedForms);
+		// TODO: We can now log per-NPC distributed forms.
+
+		if (!distributedForms.empty()) {
+
+			LinkedDistribution::Manager::GetSingleton()->ForEachLinkedDeathDistributionSet(distributedForms, [&](Forms::DistributionSet& set) {
+				detail::distribute(npcData, input, set, nullptr);  // TODO: Accumulate forms here? to log what was distributed.
+			});
+		}
 	}
 }

--- a/SPID/src/DistributeManager.cpp
+++ b/SPID/src/DistributeManager.cpp
@@ -130,7 +130,7 @@ namespace Distribute
 
 		ForEachDistributable([&]<typename Form>(Distributables<Form>& a_distributable) {
 			if (a_distributable && a_distributable.GetType() != RECORD::kDeathItem) {
-				logger::info("{}", RECORD::add[a_distributable.GetType()]);
+				logger::info("{}", RECORD::GetTypeName(a_distributable.GetType()));
 
 				auto& forms = a_distributable.GetForms();
 

--- a/SPID/src/DistributeManager.cpp
+++ b/SPID/src/DistributeManager.cpp
@@ -189,15 +189,10 @@ namespace Distribute::Event
 			const auto actor = a_event->actorDying->As<RE::Actor>();
 			const auto npc = actor ? actor->GetActorBase() : nullptr;
 			if (actor && npc) {
-				const auto npcData = NPCData(actor, npc);
+				auto npcData = NPCData(actor, npc);
 				const auto input = PCLevelMult::Input{ actor, npc, false };
 
-				for_each_form<RE::TESBoundObject>(npcData, Forms::deathItems.GetForms(input.onlyPlayerLevelEntries), input, [&](auto* deathItem, IndexOrCount idxOrCount) {
-					auto count = std::get<RandomCount>(idxOrCount);
-
-					detail::add_item(actor, deathItem, count.GetRandom());
-					return true;
-				});
+				DistributeDeathItems(npcData, input);
 			}
 		}
 

--- a/SPID/src/DistributeManager.cpp
+++ b/SPID/src/DistributeManager.cpp
@@ -189,7 +189,7 @@ namespace Distribute::Event
 			const auto actor = a_event->actorDying->As<RE::Actor>();
 			const auto npc = actor ? actor->GetActorBase() : nullptr;
 			if (actor && npc) {
-				auto npcData = NPCData(actor, npc);
+				auto       npcData = NPCData(actor, npc);
 				const auto input = PCLevelMult::Input{ actor, npc, false };
 
 				DistributeDeathItems(npcData, input);

--- a/SPID/src/LinkedDistribution.cpp
+++ b/SPID/src/LinkedDistribution.cpp
@@ -174,7 +174,7 @@ namespace LinkedDistribution
 				}
 			}
 
-			const auto& recordName = RECORD::add[linkedForms.GetType()];
+			const auto& recordName = RECORD::GetTypeName(linkedForms.GetType());
 			logger::info("Linked {}s: ", recordName);
 
 			for (const auto& [form, linkedItems] : map) {

--- a/SPID/src/LinkedDistribution.cpp
+++ b/SPID/src/LinkedDistribution.cpp
@@ -26,9 +26,9 @@ namespace LinkedDistribution
 			if (!a_key.starts_with("Linked"sv)) {
 				return false;
 			}
-			
+
 			std::string rawType = a_key.substr(6);
-			auto type = RECORD::GetType(rawType);
+			auto        type = RECORD::GetType(rawType);
 			if (type == RECORD::kTotal) {
 				logger::warn("IGNORED: Invalid Linked Form type: {}"sv, rawType);
 				return true;

--- a/SPID/src/LinkedDistribution.cpp
+++ b/SPID/src/LinkedDistribution.cpp
@@ -128,8 +128,8 @@ namespace LinkedDistribution
 					factions.Link(faction, parentForms, idxOrCount, chance, path);
 				} else if (const auto skin = form->As<RE::TESObjectARMO>(); skin) {
 					skins.Link(skin, parentForms, idxOrCount, chance, path);
-				} else if (const auto package = form->As<RE::TESForm>(); package) {
-					auto type = package->GetFormType();
+				} else {
+					auto type = form->GetFormType();
 					if (type == RE::FormType::Package || type == RE::FormType::FormList) {
 						// With generic Form entries we default to RandomCount, so we need to properly convert it to Index if it turned out to be a package.
 						Index packageIndex = 1;
@@ -142,7 +142,7 @@ namespace LinkedDistribution
 						} else {
 							packageIndex = std::get<Index>(idxOrCount);
 						}
-						packages.Link(package, parentForms, packageIndex, chance, path);
+						packages.Link(form, parentForms, packageIndex, chance, path);
 					}
 				}
 			}

--- a/SPID/src/LinkedDistribution.cpp
+++ b/SPID/src/LinkedDistribution.cpp
@@ -240,7 +240,7 @@ namespace LinkedDistribution
 	{
 		for (const auto form : targetForms) {
 			auto& linkedDeathItems = LinkedFormsForForm(form, deathItems);
-			
+
 			DistributionSet linkedEntries{
 				DistributionSet::empty<RE::SpellItem>(),
 				DistributionSet::empty<RE::BGSPerk>(),

--- a/SPID/src/LookupConfigs.cpp
+++ b/SPID/src/LookupConfigs.cpp
@@ -84,7 +84,7 @@ namespace INI
 			return group;
 		}
 
-		std::pair<Data, std::optional<std::string>> parse_ini(const std::string& a_key, const std::string& a_value, const std::string& a_path)
+		std::pair<Data, std::optional<std::string>> parse_ini(const RECORD::TYPE& typeHint, const std::string& a_value, const std::string& a_path)
 		{
 			Data data{};
 
@@ -242,12 +242,12 @@ namespace INI
 			}
 
 			//ITEMCOUNT/INDEX
-			if (a_key == "Package") {  // reuse item count for package stack index
+			if (typeHint == RECORD::kPackage) {  // reuse item count for package stack index
 				data.idxOrCount = 0;
 			}
 
 			if (kIdxOrCount < size) {
-				if (a_key == "Package") {  // If it's a package, then we only expect a single number.
+				if (typeHint == RECORD::kPackage) {  // If it's a package, then we only expect a single number.
 					if (const auto& str = sections[kIdxOrCount]; distribution::is_valid_entry(str)) {
 						data.idxOrCount = string::to_num<Index>(str);
 					}
@@ -326,8 +326,10 @@ namespace INI
 							continue;
 						}
 
-						auto [data, sanitized_str] = detail::parse_ini(key.pItem, entry, truncatedPath);
-						configs[key.pItem].emplace_back(data);
+						auto type = RECORD::GetType(key.pItem);
+						auto [data, sanitized_str] = detail::parse_ini(type, entry, truncatedPath);
+
+						configs[type].emplace_back(data);
 
 						if (sanitized_str) {
 							oldFormatMap.emplace(key, std::make_pair(entry, *sanitized_str));

--- a/SPID/src/LookupForms.cpp
+++ b/SPID/src/LookupForms.cpp
@@ -4,21 +4,64 @@
 #include "KeywordDependencies.h"
 #include "LinkedDistribution.h"
 
+
 bool LookupDistributables(RE::TESDataHandler* const dataHandler)
 {
 	using namespace Forms;
 
-	bool valid = false;
-
 	ForEachDistributable([&]<typename Form>(Distributables<Form>& a_distributable) {
 		const auto& recordName = RECORD::GetTypeName(a_distributable.GetType());
 
-		a_distributable.LookupForms(dataHandler, recordName, INI::configs[recordName]);
-		if constexpr (std::is_same_v<RE::BGSKeyword, Form>) {
-			Dependencies::ResolveKeywords();
-		}
-		a_distributable.FinishLookupForms();
+		a_distributable.LookupForms(dataHandler, recordName, INI::configs[a_distributable.GetType()]);
+	});
 
+	auto& genericForms = INI::configs[RECORD::kForm];
+
+	for (auto& rawForm : genericForms) {
+		// Add to appropriate list. (Note that type inferring doesn't recognize SleepOutfit or DeathItems)
+		LookupGenericForm<RE::TESForm>(dataHandler, rawForm, [&](auto form, auto& idxOrCount, auto& filters, std::string& path) {
+			if (const auto keyword = form->As<RE::BGSKeyword>(); keyword) {
+				keywords.GetForms().emplace_back(keywords.GetSize(), keyword, idxOrCount, filters, path);
+			} else if (const auto spell = form->As<RE::SpellItem>(); spell) {
+				spells.GetForms().emplace_back(spells.GetSize(), spell, idxOrCount, filters, path);
+			} else if (const auto perk = form->As<RE::BGSPerk>(); perk) {
+				perks.GetForms().emplace_back(perks.GetSize(), perk, idxOrCount, filters, path);
+			} else if (const auto shout = form->As<RE::TESShout>(); shout) {
+				shouts.GetForms().emplace_back(shouts.GetSize(), shout, idxOrCount, filters, path);
+			} else if (const auto item = form->As<RE::TESBoundObject>(); item) {
+				items.GetForms().emplace_back(items.GetSize(), item, idxOrCount, filters, path);
+			} else if (const auto outfit = form->As<RE::BGSOutfit>(); outfit) {
+				outfits.GetForms().emplace_back(outfits.GetSize(), outfit, idxOrCount, filters, path);
+			} else if (const auto faction = form->As<RE::TESFaction>(); faction) {
+				factions.GetForms().emplace_back(factions.GetSize(), faction, idxOrCount, filters, path);
+			} else if (const auto skin = form->As<RE::TESObjectARMO>(); skin) {
+				skins.GetForms().emplace_back(skins.GetSize(), skin, idxOrCount, filters, path);
+			} else {
+				auto type = form->GetFormType();
+				if (type == RE::FormType::Package || type == RE::FormType::FormList) {
+					// With generic Form entries we default to RandomCount, so we need to properly convert it to Index if it turned out to be a package.
+					Index packageIndex = 1;
+					if (std::holds_alternative<RandomCount>(idxOrCount)) {
+						auto& count = std::get<RandomCount>(idxOrCount);
+						if (!count.IsExact()) {
+							logger::warn("Inferred Form is a Package, but specifies a random count instead of index. Min value ({}) of the range will be used as an index.", count.min);
+						}
+						packageIndex = count.min;
+					} else {
+						packageIndex = std::get<Index>(idxOrCount);
+					}
+					packages.GetForms().emplace_back(packages.GetSize(), form, packageIndex, filters, path);
+				}
+			}
+		});		
+	}
+
+	Dependencies::ResolveKeywords();
+
+	bool valid = false;
+
+	ForEachDistributable([&]<typename Form>(Distributables<Form>& a_distributable) {
+		a_distributable.FinishLookupForms();
 		if (a_distributable) {
 			valid = true;
 		}
@@ -33,15 +76,15 @@ void LogDistributablesLookup()
 
 	logger::info("{:*^50}", "PROCESSING");
 
-	ForEachDistributable([]<typename Form>(const Distributables<Form>& a_distributable) {
+	ForEachDistributable([]<typename Form>(Distributables<Form>& a_distributable) {
 		const auto& recordName = RECORD::GetTypeName(a_distributable.GetType());
 
-		const auto all = INI::configs[recordName].size();
+		const auto all = INI::configs[a_distributable.GetType()].size();
 		const auto added = a_distributable.GetSize();
 
 		// Only log entries that are actually present in INIs.
 		if (all > 0) {
-			logger::info("Adding {}/{} {}s", added, all, recordName);
+			logger::info("Registered {}/{} {}s:", added, all, recordName);
 		}
 	});
 

--- a/SPID/src/LookupForms.cpp
+++ b/SPID/src/LookupForms.cpp
@@ -18,23 +18,23 @@ bool LookupDistributables(RE::TESDataHandler* const dataHandler)
 
 	for (auto& rawForm : genericForms) {
 		// Add to appropriate list. (Note that type inferring doesn't recognize SleepOutfit or DeathItems)
-		LookupGenericForm<RE::TESForm>(dataHandler, rawForm, [&](auto form, auto& idxOrCount, auto& filters, std::string& path) {
+		LookupGenericForm<RE::TESForm>(dataHandler, rawForm, [&](bool isValid, auto form, const auto& idxOrCount, const auto& filters, const auto& path) {
 			if (const auto keyword = form->As<RE::BGSKeyword>(); keyword) {
-				keywords.GetForms().emplace_back(keywords.GetSize(), keyword, idxOrCount, filters, path);
+				keywords.EmplaceForm(isValid, keyword, idxOrCount, filters, path);
 			} else if (const auto spell = form->As<RE::SpellItem>(); spell) {
-				spells.GetForms().emplace_back(spells.GetSize(), spell, idxOrCount, filters, path);
+				spells.EmplaceForm(isValid, spell, idxOrCount, filters, path);
 			} else if (const auto perk = form->As<RE::BGSPerk>(); perk) {
-				perks.GetForms().emplace_back(perks.GetSize(), perk, idxOrCount, filters, path);
+				perks.EmplaceForm(isValid, perk, idxOrCount, filters, path);
 			} else if (const auto shout = form->As<RE::TESShout>(); shout) {
-				shouts.GetForms().emplace_back(shouts.GetSize(), shout, idxOrCount, filters, path);
+				shouts.EmplaceForm(isValid, shout, idxOrCount, filters, path);
 			} else if (const auto item = form->As<RE::TESBoundObject>(); item) {
-				items.GetForms().emplace_back(items.GetSize(), item, idxOrCount, filters, path);
+				items.EmplaceForm(isValid, item, idxOrCount, filters, path);
 			} else if (const auto outfit = form->As<RE::BGSOutfit>(); outfit) {
-				outfits.GetForms().emplace_back(outfits.GetSize(), outfit, idxOrCount, filters, path);
+				outfits.EmplaceForm(isValid, outfit, idxOrCount, filters, path);
 			} else if (const auto faction = form->As<RE::TESFaction>(); faction) {
-				factions.GetForms().emplace_back(factions.GetSize(), faction, idxOrCount, filters, path);
+				factions.EmplaceForm(isValid, faction, idxOrCount, filters, path);
 			} else if (const auto skin = form->As<RE::TESObjectARMO>(); skin) {
-				skins.GetForms().emplace_back(skins.GetSize(), skin, idxOrCount, filters, path);
+				skins.EmplaceForm(isValid, skin, idxOrCount, filters, path);
 			} else {
 				auto type = form->GetFormType();
 				if (type == RE::FormType::Package || type == RE::FormType::FormList) {
@@ -49,7 +49,7 @@ bool LookupDistributables(RE::TESDataHandler* const dataHandler)
 					} else {
 						packageIndex = std::get<Index>(idxOrCount);
 					}
-					packages.GetForms().emplace_back(packages.GetSize(), form, packageIndex, filters, path);
+					packages.EmplaceForm(isValid, form, packageIndex, filters, path);
 				}
 			}
 		});
@@ -78,12 +78,12 @@ void LogDistributablesLookup()
 	ForEachDistributable([]<typename Form>(Distributables<Form>& a_distributable) {
 		const auto& recordName = RECORD::GetTypeName(a_distributable.GetType());
 
-		const auto all = INI::configs[a_distributable.GetType()].size();
 		const auto added = a_distributable.GetSize();
+		const auto all = a_distributable.GetLookupCount();
 
 		// Only log entries that are actually present in INIs.
 		if (all > 0) {
-			logger::info("Registered {}/{} {}s:", added, all, recordName);
+			logger::info("Registered {}/{} {}s", added, all, recordName);
 		}
 	});
 

--- a/SPID/src/LookupForms.cpp
+++ b/SPID/src/LookupForms.cpp
@@ -11,7 +11,7 @@ bool LookupDistributables(RE::TESDataHandler* const dataHandler)
 	bool valid = false;
 
 	ForEachDistributable([&]<typename Form>(Distributables<Form>& a_distributable) {
-		const auto& recordName = RECORD::add[a_distributable.GetType()];
+		const auto& recordName = RECORD::GetTypeName(a_distributable.GetType());
 
 		a_distributable.LookupForms(dataHandler, recordName, INI::configs[recordName]);
 		if constexpr (std::is_same_v<RE::BGSKeyword, Form>) {
@@ -34,7 +34,7 @@ void LogDistributablesLookup()
 	logger::info("{:*^50}", "PROCESSING");
 
 	ForEachDistributable([]<typename Form>(const Distributables<Form>& a_distributable) {
-		const auto& recordName = RECORD::add[a_distributable.GetType()];
+		const auto& recordName = RECORD::GetTypeName(a_distributable.GetType());
 
 		const auto all = INI::configs[recordName].size();
 		const auto added = a_distributable.GetSize();

--- a/SPID/src/LookupForms.cpp
+++ b/SPID/src/LookupForms.cpp
@@ -4,7 +4,6 @@
 #include "KeywordDependencies.h"
 #include "LinkedDistribution.h"
 
-
 bool LookupDistributables(RE::TESDataHandler* const dataHandler)
 {
 	using namespace Forms;
@@ -53,7 +52,7 @@ bool LookupDistributables(RE::TESDataHandler* const dataHandler)
 					packages.GetForms().emplace_back(packages.GetSize(), form, packageIndex, filters, path);
 				}
 			}
-		});		
+		});
 	}
 
 	Dependencies::ResolveKeywords();

--- a/SPID/src/LookupForms.cpp
+++ b/SPID/src/LookupForms.cpp
@@ -78,14 +78,14 @@ void LogExclusiveGroupsLookup()
 	}
 }
 
-void LookupLinkedItems(RE::TESDataHandler* const dataHandler)
+void LookupLinkedForms(RE::TESDataHandler* const dataHandler)
 {
-	LinkedDistribution::Manager::GetSingleton()->LookupLinkedItems(dataHandler);
+	LinkedDistribution::Manager::GetSingleton()->LookupLinkedForms(dataHandler);
 }
 
-void LogLinkedItemsLookup()
+void LogLinkedFormsLookup()
 {
-	LinkedDistribution::Manager::GetSingleton()->LogLinkedItemsLookup();
+	LinkedDistribution::Manager::GetSingleton()->LogLinkedFormsLookup();
 }
 
 bool Lookup::LookupForms()
@@ -104,8 +104,8 @@ bool Lookup::LookupForms()
 			logger::info("Lookup took {}μs / {}ms", timer.duration_μs(), timer.duration_ms());
 		}
 
-		LookupLinkedItems(dataHandler);
-		LogLinkedItemsLookup();
+		LookupLinkedForms(dataHandler);
+		LogLinkedFormsLookup();
 
 		LookupExclusiveGroups(dataHandler);
 		LogExclusiveGroupsLookup();


### PR DESCRIPTION
This change expands Linked Forms feature by allowing to make any regular entry as linked using `Linked` prefix, e.g. `LinkedItem`, `LinkedOutfit`, etc. This also introduces type inference by allowing to write `LinkedForm` and let SPID figure out form's type.

As a side benefit it adds support for linking DeathItems. Note that Only DeathItems can be linked to other DeathItems 🙂 

TODO:
- [x] Backport type inferring to regular entries as well.

This now also allows to write
```ini
Form = 0x12345|...
```
without specifying type of the form you want.

Explicit form type is still useful as it can check whether user's intention matches the actual form type.

P.S. Performance impact of type inference is negligible. (2030 forms scored average ~204ms with both explicit and inferred types)